### PR TITLE
feat: remove upstreams/downstreams from UpsertEntity, unify edge API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMMIT := $(shell git rev-parse --short HEAD)
 TAG := "$(shell git rev-list --tags --max-count=1)"
 VERSION := "$(shell git describe --tags ${TAG})-next"
 BUILD_DIR=dist
-PROTON_COMMIT := "eefb04d"
+PROTON_COMMIT := "115c256"
 
 .PHONY: all build clean test tidy vet proto setup format generate lint install
 

--- a/core/entity/service.go
+++ b/core/entity/service.go
@@ -55,24 +55,6 @@ func (s *Service) Upsert(ctx context.Context, ns *namespace.Namespace, ent *Enti
 	return id, nil
 }
 
-func (s *Service) UpsertWithEdges(ctx context.Context, ns *namespace.Namespace, ent *Entity, upstreams, downstreams []string) (string, error) {
-	id, err := s.Upsert(ctx, ns, ent)
-	if err != nil {
-		return "", err
-	}
-
-	if s.edges != nil {
-		for _, us := range upstreams {
-			_ = s.edges.Upsert(ctx, ns, &Edge{SourceURN: us, TargetURN: ent.URN, Type: "lineage", Properties: map[string]interface{}{"root": ent.URN}})
-		}
-		for _, ds := range downstreams {
-			_ = s.edges.Upsert(ctx, ns, &Edge{SourceURN: ent.URN, TargetURN: ds, Type: "lineage", Properties: map[string]interface{}{"root": ent.URN}})
-		}
-	}
-
-	return id, nil
-}
-
 func (s *Service) GetByURN(ctx context.Context, ns *namespace.Namespace, urn string) (Entity, error) {
 	return s.repo.GetByURN(ctx, ns, urn)
 }

--- a/core/entity/service_test.go
+++ b/core/entity/service_test.go
@@ -267,8 +267,8 @@ func TestService_GetContext_DefaultDepth(t *testing.T) {
 	_, _ = svc.Upsert(ctx, ns, &Entity{URN: "urn:b", Type: TypeTable, Name: "b"})
 	_, _ = svc.Upsert(ctx, ns, &Entity{URN: "urn:c", Type: TypeTable, Name: "c"})
 	edges.edges = []Edge{
-		{SourceURN: "urn:a", TargetURN: "urn:b", Type: "lineage"},
-		{SourceURN: "urn:b", TargetURN: "urn:c", Type: "lineage"},
+		{SourceURN: "urn:a", TargetURN: "urn:b", Type: "derived_from"},
+		{SourceURN: "urn:b", TargetURN: "urn:c", Type: "derived_from"},
 	}
 
 	// depth=0 should default to 1 (only direct neighbors of B)
@@ -297,9 +297,9 @@ func TestService_GetContext_MultiHop(t *testing.T) {
 	_, _ = svc.Upsert(ctx, ns, &Entity{URN: "urn:c", Type: TypeTable, Name: "c"})
 	_, _ = svc.Upsert(ctx, ns, &Entity{URN: "urn:d", Type: TypeTable, Name: "d"})
 	edges.edges = []Edge{
-		{SourceURN: "urn:a", TargetURN: "urn:b", Type: "lineage"},
-		{SourceURN: "urn:b", TargetURN: "urn:c", Type: "lineage"},
-		{SourceURN: "urn:c", TargetURN: "urn:d", Type: "lineage"},
+		{SourceURN: "urn:a", TargetURN: "urn:b", Type: "derived_from"},
+		{SourceURN: "urn:b", TargetURN: "urn:c", Type: "derived_from"},
+		{SourceURN: "urn:c", TargetURN: "urn:d", Type: "derived_from"},
 	}
 
 	// depth=2 from B should reach A, C, and D
@@ -366,9 +366,9 @@ func TestService_GetContext_CycleHandling(t *testing.T) {
 	_, _ = svc.Upsert(ctx, ns, &Entity{URN: "urn:b", Type: TypeTable, Name: "b"})
 	_, _ = svc.Upsert(ctx, ns, &Entity{URN: "urn:c", Type: TypeTable, Name: "c"})
 	edges.edges = []Edge{
-		{SourceURN: "urn:a", TargetURN: "urn:b", Type: "lineage"},
-		{SourceURN: "urn:b", TargetURN: "urn:c", Type: "lineage"},
-		{SourceURN: "urn:c", TargetURN: "urn:a", Type: "lineage"},
+		{SourceURN: "urn:a", TargetURN: "urn:b", Type: "derived_from"},
+		{SourceURN: "urn:b", TargetURN: "urn:c", Type: "derived_from"},
+		{SourceURN: "urn:c", TargetURN: "urn:a", Type: "derived_from"},
 	}
 
 	// depth=3 should not infinite loop
@@ -421,57 +421,12 @@ func TestService_GetByID(t *testing.T) {
 	}
 }
 
-func TestService_UpsertWithEdges(t *testing.T) {
-	repo := newMockRepo()
-	edges := &mockEdgeRepo{}
-	svc := NewService(repo, edges, nil)
-	ctx := context.Background()
-	ns := namespace.DefaultNamespace
-
-	ent := &Entity{URN: "urn:table:main", Type: TypeTable, Name: "main"}
-	upstreams := []string{"urn:table:source1", "urn:table:source2"}
-	downstreams := []string{"urn:table:sink1"}
-
-	id, err := svc.UpsertWithEdges(ctx, ns, ent, upstreams, downstreams)
-	if err != nil {
-		t.Fatalf("UpsertWithEdges failed: %v", err)
-	}
-	if id == "" {
-		t.Fatal("expected non-empty ID")
-	}
-
-	// Should have 2 upstream edges + 1 downstream edge = 3 total
-	if len(edges.edges) != 3 {
-		t.Fatalf("expected 3 edges, got %d", len(edges.edges))
-	}
-
-	// Check upstream edges: source -> main
-	if edges.edges[0].SourceURN != "urn:table:source1" || edges.edges[0].TargetURN != "urn:table:main" {
-		t.Errorf("upstream edge 0: got source=%q target=%q", edges.edges[0].SourceURN, edges.edges[0].TargetURN)
-	}
-	if edges.edges[1].SourceURN != "urn:table:source2" || edges.edges[1].TargetURN != "urn:table:main" {
-		t.Errorf("upstream edge 1: got source=%q target=%q", edges.edges[1].SourceURN, edges.edges[1].TargetURN)
-	}
-
-	// Check downstream edge: main -> sink
-	if edges.edges[2].SourceURN != "urn:table:main" || edges.edges[2].TargetURN != "urn:table:sink1" {
-		t.Errorf("downstream edge: got source=%q target=%q", edges.edges[2].SourceURN, edges.edges[2].TargetURN)
-	}
-
-	// All edges should be lineage type
-	for i, e := range edges.edges {
-		if e.Type != "lineage" {
-			t.Errorf("edge %d: expected type 'lineage', got %q", i, e.Type)
-		}
-	}
-}
-
 func TestService_GetImpact(t *testing.T) {
 	repo := newMockRepo()
 	edges := &mockEdgeRepo{
 		downstreamEdges: []Edge{
-			{SourceURN: "urn:a", TargetURN: "urn:b", Type: "lineage"},
-			{SourceURN: "urn:b", TargetURN: "urn:c", Type: "lineage"},
+			{SourceURN: "urn:a", TargetURN: "urn:b", Type: "derived_from"},
+			{SourceURN: "urn:b", TargetURN: "urn:c", Type: "derived_from"},
 		},
 	}
 	svc := NewService(repo, edges, nil)

--- a/gen/buf/validate/validate.pb.go
+++ b/gen/buf/validate/validate.pb.go
@@ -41,7 +41,7 @@
 //
 // These rules are enforced at runtime by language-specific libraries.
 // See the [developer quickstart](https://protovalidate.com/quickstart/) to get started, or go directly to the runtime library for your language:
-// [Go](https://github.com/bufbuild/protovalidate-go)
+// [Go](https://github.com/bufbuild/protovalidate-go),
 // [JavaScript/TypeScript](https://github.com/bufbuild/protovalidate-es),
 // [Java](https://github.com/bufbuild/protovalidate-java),
 // [Python](https://github.com/bufbuild/protovalidate-python),
@@ -396,7 +396,7 @@ type MessageRules struct {
 	//	  // The field `foo` must be greater than 42.
 	//	  option (buf.validate.message).cel = {
 	//	    id: "my_message.value",
-	//	    message: "value must be greater than 42",
+	//	    message: "must be greater than 42",
 	//	    expression: "this.foo > 42",
 	//	  };
 	//	  optional int32 foo = 1;
@@ -648,7 +648,7 @@ type FieldRules struct {
 	//	  // The field `value` must be greater than 42.
 	//	  optional int32 value = 1 [(buf.validate.field).cel = {
 	//	    id: "my_message.value",
-	//	    message: "value must be greater than 42",
+	//	    message: "must be greater than 42",
 	//	    expression: "this > 42",
 	//	  }];
 	//	}
@@ -1174,7 +1174,7 @@ type PredefinedRules struct {
 	//	  // The field `value` must be greater than 42.
 	//	  optional int32 value = 1 [(buf.validate.predefined).cel = {
 	//	    id: "my_message.value",
-	//	    message: "value must be greater than 42",
+	//	    message: "must be greater than 42",
 	//	    expression: "this > 42",
 	//	  }];
 	//	}
@@ -1255,13 +1255,13 @@ type FloatRules struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	  // value must be in list [1.0, 2.0, 3.0]
+	//	  // must be in list [1.0, 2.0, 3.0]
 	//	  float value = 1 [(buf.validate.field).float = { in: [1.0, 2.0, 3.0] }];
 	//	}
 	//
 	// ```
 	In []float32 `protobuf:"fixed32,6,rep,name=in" json:"in,omitempty"`
-	// `in` requires the field value to not be equal to any of the specified
+	// `not_in` requires the field value to not be equal to any of the specified
 	// values. If the field value is one of the specified values, an error
 	// message is generated.
 	//
@@ -1424,7 +1424,7 @@ type FloatRules_Lt struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	  // value must be less than 10.0
+	//	  // must be less than 10.0
 	//	  float value = 1 [(buf.validate.field).float.lt = 10.0];
 	//	}
 	//
@@ -1440,7 +1440,7 @@ type FloatRules_Lte struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	  // value must be less than or equal to 10.0
+	//	  // must be less than or equal to 10.0
 	//	  float value = 1 [(buf.validate.field).float.lte = 10.0];
 	//	}
 	//
@@ -1466,13 +1466,13 @@ type FloatRules_Gt struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	  // value must be greater than 5.0 [float.gt]
+	//	  // must be greater than 5.0 [float.gt]
 	//	  float value = 1 [(buf.validate.field).float.gt = 5.0];
 	//
-	//	  // value must be greater than 5 and less than 10.0 [float.gt_lt]
+	//	  // must be greater than 5 and less than 10.0 [float.gt_lt]
 	//	  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
 	//
-	//	  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
 	//	  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
 	//	}
 	//
@@ -1490,13 +1490,13 @@ type FloatRules_Gte struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	  // value must be greater than or equal to 5.0 [float.gte]
+	//	  // must be greater than or equal to 5.0 [float.gte]
 	//	  float value = 1 [(buf.validate.field).float.gte = 5.0];
 	//
-	//	  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+	//	  // must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
 	//	  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
 	//
-	//	  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
 	//	  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
 	//	}
 	//
@@ -1541,7 +1541,7 @@ type DoubleRules struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	  // value must be in list [1.0, 2.0, 3.0]
+	//	  // must be in list [1.0, 2.0, 3.0]
 	//	  double value = 1 [(buf.validate.field).double = { in: [1.0, 2.0, 3.0] }];
 	//	}
 	//
@@ -1710,7 +1710,7 @@ type DoubleRules_Lt struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	  // value must be less than 10.0
+	//	  // must be less than 10.0
 	//	  double value = 1 [(buf.validate.field).double.lt = 10.0];
 	//	}
 	//
@@ -1726,7 +1726,7 @@ type DoubleRules_Lte struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	  // value must be less than or equal to 10.0
+	//	  // must be less than or equal to 10.0
 	//	  double value = 1 [(buf.validate.field).double.lte = 10.0];
 	//	}
 	//
@@ -1752,13 +1752,13 @@ type DoubleRules_Gt struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	  // value must be greater than 5.0 [double.gt]
+	//	  // must be greater than 5.0 [double.gt]
 	//	  double value = 1 [(buf.validate.field).double.gt = 5.0];
 	//
-	//	  // value must be greater than 5 and less than 10.0 [double.gt_lt]
+	//	  // must be greater than 5 and less than 10.0 [double.gt_lt]
 	//	  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
 	//
-	//	  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
 	//	  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
 	//	}
 	//
@@ -1776,13 +1776,13 @@ type DoubleRules_Gte struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	  // value must be greater than or equal to 5.0 [double.gte]
+	//	  // must be greater than or equal to 5.0 [double.gte]
 	//	  double value = 1 [(buf.validate.field).double.gte = 5.0];
 	//
-	//	  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+	//	  // must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
 	//	  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
 	//
-	//	  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
 	//	  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
 	//	}
 	//
@@ -1827,7 +1827,7 @@ type Int32Rules struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  int32 value = 1 [(buf.validate.field).int32 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -1986,7 +1986,7 @@ type Int32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  int32 value = 1 [(buf.validate.field).int32.lt = 10];
 	//	}
 	//
@@ -2002,7 +2002,7 @@ type Int32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  int32 value = 1 [(buf.validate.field).int32.lte = 10];
 	//	}
 	//
@@ -2028,13 +2028,13 @@ type Int32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	  // value must be greater than 5 [int32.gt]
+	//	  // must be greater than 5 [int32.gt]
 	//	  int32 value = 1 [(buf.validate.field).int32.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [int32.gt_lt]
+	//	  // must be greater than 5 and less than 10 [int32.gt_lt]
 	//	  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
 	//	  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -2052,13 +2052,13 @@ type Int32Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	  // value must be greater than or equal to 5 [int32.gte]
+	//	  // must be greater than or equal to 5 [int32.gte]
 	//	  int32 value = 1 [(buf.validate.field).int32.gte = 5];
 	//
-	//	  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+	//	  // must be greater than or equal to 5 and less than 10 [int32.gte_lt]
 	//	  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
 	//
-	//	  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
 	//	  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -2103,7 +2103,7 @@ type Int64Rules struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  int64 value = 1 [(buf.validate.field).int64 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -2262,7 +2262,7 @@ type Int64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  int64 value = 1 [(buf.validate.field).int64.lt = 10];
 	//	}
 	//
@@ -2278,7 +2278,7 @@ type Int64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  int64 value = 1 [(buf.validate.field).int64.lte = 10];
 	//	}
 	//
@@ -2304,13 +2304,13 @@ type Int64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	  // value must be greater than 5 [int64.gt]
+	//	  // must be greater than 5 [int64.gt]
 	//	  int64 value = 1 [(buf.validate.field).int64.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [int64.gt_lt]
+	//	  // must be greater than 5 and less than 10 [int64.gt_lt]
 	//	  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
 	//	  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -2328,13 +2328,13 @@ type Int64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	  // value must be greater than or equal to 5 [int64.gte]
+	//	  // must be greater than or equal to 5 [int64.gte]
 	//	  int64 value = 1 [(buf.validate.field).int64.gte = 5];
 	//
-	//	  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+	//	  // must be greater than or equal to 5 and less than 10 [int64.gte_lt]
 	//	  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
 	//
-	//	  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
 	//	  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -2379,7 +2379,7 @@ type UInt32Rules struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  uint32 value = 1 [(buf.validate.field).uint32 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -2538,7 +2538,7 @@ type UInt32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
 	//	}
 	//
@@ -2554,7 +2554,7 @@ type UInt32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
 	//	}
 	//
@@ -2580,13 +2580,13 @@ type UInt32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	  // value must be greater than 5 [uint32.gt]
+	//	  // must be greater than 5 [uint32.gt]
 	//	  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [uint32.gt_lt]
+	//	  // must be greater than 5 and less than 10 [uint32.gt_lt]
 	//	  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
 	//	  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -2604,13 +2604,13 @@ type UInt32Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	  // value must be greater than or equal to 5 [uint32.gte]
+	//	  // must be greater than or equal to 5 [uint32.gte]
 	//	  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
 	//
-	//	  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+	//	  // must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
 	//	  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
 	//
-	//	  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
 	//	  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -2655,7 +2655,7 @@ type UInt64Rules struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  uint64 value = 1 [(buf.validate.field).uint64 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -2814,7 +2814,7 @@ type UInt64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
 	//	}
 	//
@@ -2830,7 +2830,7 @@ type UInt64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
 	//	}
 	//
@@ -2856,13 +2856,13 @@ type UInt64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	  // value must be greater than 5 [uint64.gt]
+	//	  // must be greater than 5 [uint64.gt]
 	//	  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [uint64.gt_lt]
+	//	  // must be greater than 5 and less than 10 [uint64.gt_lt]
 	//	  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
 	//	  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -2880,13 +2880,13 @@ type UInt64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	  // value must be greater than or equal to 5 [uint64.gte]
+	//	  // must be greater than or equal to 5 [uint64.gte]
 	//	  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
 	//
-	//	  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+	//	  // must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
 	//	  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
 	//
-	//	  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
 	//	  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -2930,7 +2930,7 @@ type SInt32Rules struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  sint32 value = 1 [(buf.validate.field).sint32 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -3089,7 +3089,7 @@ type SInt32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
 	//	}
 	//
@@ -3105,7 +3105,7 @@ type SInt32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
 	//	}
 	//
@@ -3131,13 +3131,13 @@ type SInt32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	  // value must be greater than 5 [sint32.gt]
+	//	  // must be greater than 5 [sint32.gt]
 	//	  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [sint32.gt_lt]
+	//	  // must be greater than 5 and less than 10 [sint32.gt_lt]
 	//	  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
 	//	  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -3155,13 +3155,13 @@ type SInt32Rules_Gte struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	 // value must be greater than or equal to 5 [sint32.gte]
+	//	 // must be greater than or equal to 5 [sint32.gte]
 	//	 sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [sint32.gte_lt]
+	//	 // must be greater than or equal to 5 and less than 10 [sint32.gte_lt]
 	//	 sint32 other_value = 2 [(buf.validate.field).sint32 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
+	//	 // must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
 	//	 sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -3205,7 +3205,7 @@ type SInt64Rules struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  sint64 value = 1 [(buf.validate.field).sint64 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -3364,7 +3364,7 @@ type SInt64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
 	//	}
 	//
@@ -3380,7 +3380,7 @@ type SInt64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
 	//	}
 	//
@@ -3406,13 +3406,13 @@ type SInt64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	  // value must be greater than 5 [sint64.gt]
+	//	  // must be greater than 5 [sint64.gt]
 	//	  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [sint64.gt_lt]
+	//	  // must be greater than 5 and less than 10 [sint64.gt_lt]
 	//	  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
 	//	  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -3430,13 +3430,13 @@ type SInt64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	  // value must be greater than or equal to 5 [sint64.gte]
+	//	  // must be greater than or equal to 5 [sint64.gte]
 	//	  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
 	//
-	//	  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+	//	  // must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
 	//	  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
 	//
-	//	  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
 	//	  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -3480,7 +3480,7 @@ type Fixed32Rules struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  fixed32 value = 1 [(buf.validate.field).fixed32 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -3639,7 +3639,7 @@ type Fixed32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
 	//	}
 	//
@@ -3655,7 +3655,7 @@ type Fixed32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
 	//	}
 	//
@@ -3681,13 +3681,13 @@ type Fixed32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	  // value must be greater than 5 [fixed32.gt]
+	//	  // must be greater than 5 [fixed32.gt]
 	//	  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+	//	  // must be greater than 5 and less than 10 [fixed32.gt_lt]
 	//	  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
 	//	  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -3705,13 +3705,13 @@ type Fixed32Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	  // value must be greater than or equal to 5 [fixed32.gte]
+	//	  // must be greater than or equal to 5 [fixed32.gte]
 	//	  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
 	//
-	//	  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+	//	  // must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
 	//	  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
 	//
-	//	  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
 	//	  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -3755,7 +3755,7 @@ type Fixed64Rules struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  fixed64 value = 1 [(buf.validate.field).fixed64 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -3914,7 +3914,7 @@ type Fixed64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
 	//	}
 	//
@@ -3930,7 +3930,7 @@ type Fixed64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
 	//	}
 	//
@@ -3956,13 +3956,13 @@ type Fixed64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	  // value must be greater than 5 [fixed64.gt]
+	//	  // must be greater than 5 [fixed64.gt]
 	//	  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+	//	  // must be greater than 5 and less than 10 [fixed64.gt_lt]
 	//	  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
 	//	  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -3980,13 +3980,13 @@ type Fixed64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	  // value must be greater than or equal to 5 [fixed64.gte]
+	//	  // must be greater than or equal to 5 [fixed64.gte]
 	//	  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
 	//
-	//	  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+	//	  // must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
 	//	  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
 	//
-	//	  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
 	//	  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -4030,7 +4030,7 @@ type SFixed32Rules struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -4189,7 +4189,7 @@ type SFixed32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
 	//	}
 	//
@@ -4205,7 +4205,7 @@ type SFixed32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
 	//	}
 	//
@@ -4231,13 +4231,13 @@ type SFixed32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	  // value must be greater than 5 [sfixed32.gt]
+	//	  // must be greater than 5 [sfixed32.gt]
 	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+	//	  // must be greater than 5 and less than 10 [sfixed32.gt_lt]
 	//	  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
 	//	  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -4255,13 +4255,13 @@ type SFixed32Rules_Gte struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	  // value must be greater than or equal to 5 [sfixed32.gte]
+	//	  // must be greater than or equal to 5 [sfixed32.gte]
 	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
 	//
-	//	  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+	//	  // must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
 	//	  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
 	//
-	//	  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
 	//	  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -4305,7 +4305,7 @@ type SFixed64Rules struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	  // value must be in list [1, 2, 3]
+	//	  // must be in list [1, 2, 3]
 	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64 = { in: [1, 2, 3] }];
 	//	}
 	//
@@ -4464,7 +4464,7 @@ type SFixed64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	  // value must be less than 10
+	//	  // must be less than 10
 	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
 	//	}
 	//
@@ -4480,7 +4480,7 @@ type SFixed64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	  // value must be less than or equal to 10
+	//	  // must be less than or equal to 10
 	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
 	//	}
 	//
@@ -4506,13 +4506,13 @@ type SFixed64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	  // value must be greater than 5 [sfixed64.gt]
+	//	  // must be greater than 5 [sfixed64.gt]
 	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
 	//
-	//	  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+	//	  // must be greater than 5 and less than 10 [sfixed64.gt_lt]
 	//	  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
 	//
-	//	  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+	//	  // must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
 	//	  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
 	//	}
 	//
@@ -4530,13 +4530,13 @@ type SFixed64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	  // value must be greater than or equal to 5 [sfixed64.gte]
+	//	  // must be greater than or equal to 5 [sfixed64.gte]
 	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
 	//
-	//	  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+	//	  // must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
 	//	  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
 	//
-	//	  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+	//	  // must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
 	//	  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
 	//	}
 	//
@@ -4799,7 +4799,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be in list ["apple", "banana"]
+	//	  // must be in list ["apple", "banana"]
 	//	  string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
 	//	}
 	//
@@ -4840,6 +4840,8 @@ type StringRules struct {
 	//	*StringRules_Ipv6Prefix
 	//	*StringRules_HostAndPort
 	//	*StringRules_Ulid
+	//	*StringRules_ProtobufFqn
+	//	*StringRules_ProtobufDotFqn
 	//	*StringRules_WellKnownRegex
 	WellKnown isStringRules_WellKnown `protobuf_oneof:"well_known"`
 	// This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
@@ -5174,6 +5176,24 @@ func (x *StringRules) GetUlid() bool {
 	return false
 }
 
+func (x *StringRules) GetProtobufFqn() bool {
+	if x != nil {
+		if x, ok := x.WellKnown.(*StringRules_ProtobufFqn); ok {
+			return x.ProtobufFqn
+		}
+	}
+	return false
+}
+
+func (x *StringRules) GetProtobufDotFqn() bool {
+	if x != nil {
+		if x, ok := x.WellKnown.(*StringRules_ProtobufDotFqn); ok {
+			return x.ProtobufDotFqn
+		}
+	}
+	return false
+}
+
 func (x *StringRules) GetWellKnownRegex() KnownRegex {
 	if x != nil {
 		if x, ok := x.WellKnown.(*StringRules_WellKnownRegex); ok {
@@ -5215,7 +5235,7 @@ type StringRules_Email struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid email address
+	//	  // must be a valid email address
 	//	  string value = 1 [(buf.validate.field).string.email = true];
 	//	}
 	//
@@ -5240,7 +5260,7 @@ type StringRules_Hostname struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid hostname
+	//	  // must be a valid hostname
 	//	  string value = 1 [(buf.validate.field).string.hostname = true];
 	//	}
 	//
@@ -5264,7 +5284,7 @@ type StringRules_Ip struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid IP address
+	//	  // must be a valid IP address
 	//	  string value = 1 [(buf.validate.field).string.ip = true];
 	//	}
 	//
@@ -5280,7 +5300,7 @@ type StringRules_Ipv4 struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid IPv4 address
+	//	  // must be a valid IPv4 address
 	//	  string value = 1 [(buf.validate.field).string.ipv4 = true];
 	//	}
 	//
@@ -5296,7 +5316,7 @@ type StringRules_Ipv6 struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid IPv6 address
+	//	  // must be a valid IPv6 address
 	//	  string value = 1 [(buf.validate.field).string.ipv6 = true];
 	//	}
 	//
@@ -5316,7 +5336,7 @@ type StringRules_Uri struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid URI
+	//	  // must be a valid URI
 	//	  string value = 1 [(buf.validate.field).string.uri = true];
 	//	}
 	//
@@ -5339,7 +5359,7 @@ type StringRules_UriRef struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid URI Reference
+	//	  // must be a valid URI Reference
 	//	  string value = 1 [(buf.validate.field).string.uri_ref = true];
 	//	}
 	//
@@ -5356,7 +5376,7 @@ type StringRules_Address struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid hostname, or ip address
+	//	  // must be a valid hostname, or ip address
 	//	  string value = 1 [(buf.validate.field).string.address = true];
 	//	}
 	//
@@ -5372,7 +5392,7 @@ type StringRules_Uuid struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid UUID
+	//	  // must be a valid UUID
 	//	  string value = 1 [(buf.validate.field).string.uuid = true];
 	//	}
 	//
@@ -5389,7 +5409,7 @@ type StringRules_Tuuid struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid trimmed UUID
+	//	  // must be a valid trimmed UUID
 	//	  string value = 1 [(buf.validate.field).string.tuuid = true];
 	//	}
 	//
@@ -5406,7 +5426,7 @@ type StringRules_IpWithPrefixlen struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid IP with prefix length
+	//	  // must be a valid IP with prefix length
 	//	   string value = 1 [(buf.validate.field).string.ip_with_prefixlen = true];
 	//	}
 	//
@@ -5423,7 +5443,7 @@ type StringRules_Ipv4WithPrefixlen struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid IPv4 address with prefix length
+	//	  // must be a valid IPv4 address with prefix length
 	//	   string value = 1 [(buf.validate.field).string.ipv4_with_prefixlen = true];
 	//	}
 	//
@@ -5440,7 +5460,7 @@ type StringRules_Ipv6WithPrefixlen struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid IPv6 address prefix length
+	//	  // must be a valid IPv6 address prefix length
 	//	   string value = 1 [(buf.validate.field).string.ipv6_with_prefixlen = true];
 	//	}
 	//
@@ -5462,7 +5482,7 @@ type StringRules_IpPrefix struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid IP prefix
+	//	  // must be a valid IP prefix
 	//	   string value = 1 [(buf.validate.field).string.ip_prefix = true];
 	//	}
 	//
@@ -5484,7 +5504,7 @@ type StringRules_Ipv4Prefix struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid IPv4 prefix
+	//	  // must be a valid IPv4 prefix
 	//	   string value = 1 [(buf.validate.field).string.ipv4_prefix = true];
 	//	}
 	//
@@ -5506,7 +5526,7 @@ type StringRules_Ipv6Prefix struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid IPv6 prefix
+	//	  // must be a valid IPv6 prefix
 	//	   string value = 1 [(buf.validate.field).string.ipv6_prefix = true];
 	//	}
 	//
@@ -5515,7 +5535,7 @@ type StringRules_Ipv6Prefix struct {
 }
 
 type StringRules_HostAndPort struct {
-	// `host_and_port` specifies that the field value must be valid host/port
+	// `host_and_port` specifies that the field value must be a valid host/port
 	// pair—for example, "example.com:8080".
 	//
 	// The host can be one of:
@@ -5536,12 +5556,72 @@ type StringRules_Ulid struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid ULID
+	//	  // must be a valid ULID
 	//	  string value = 1 [(buf.validate.field).string.ulid = true];
 	//	}
 	//
 	// ```
 	Ulid bool `protobuf:"varint,35,opt,name=ulid,oneof"`
+}
+
+type StringRules_ProtobufFqn struct {
+	// `protobuf_fqn` specifies that the field value must be a valid fully-qualified
+	// Protobuf name as defined by the [Protobuf Language Specification](https://protobuf.com/docs/language-spec).
+	//
+	// A fully-qualified Protobuf name is a dot-separated list of Protobuf identifiers,
+	// where each identifier starts with a letter or underscore and is followed by zero or
+	// more letters, underscores, or digits.
+	//
+	// Examples: "buf.validate", "google.protobuf.Timestamp", "my_package.MyMessage".
+	//
+	// Note: historically, fully-qualified Protobuf names were represented with a leading
+	// dot (for example, ".buf.validate.StringRules"). Modern Protobuf does not use the
+	// leading dot, and most fully-qualified names are represented without it. Use
+	// `protobuf_dot_fqn` if a leading dot is required.
+	//
+	// If the field value isn't a valid fully-qualified Protobuf name, an error message
+	// will be generated.
+	//
+	// ```proto
+	//
+	//	message MyString {
+	//	  // value must be a valid fully-qualified Protobuf name
+	//	  string value = 1 [(buf.validate.field).string.protobuf_fqn = true];
+	//	}
+	//
+	// ```
+	ProtobufFqn bool `protobuf:"varint,37,opt,name=protobuf_fqn,json=protobufFqn,oneof"`
+}
+
+type StringRules_ProtobufDotFqn struct {
+	// `protobuf_dot_fqn` specifies that the field value must be a valid fully-qualified
+	// Protobuf name with a leading dot, as defined by the
+	// [Protobuf Language Specification](https://protobuf.com/docs/language-spec).
+	//
+	// A fully-qualified Protobuf name with a leading dot is a dot followed by a
+	// dot-separated list of Protobuf identifiers, where each identifier starts with a
+	// letter or underscore and is followed by zero or more letters, underscores, or
+	// digits.
+	//
+	// Examples: ".buf.validate", ".google.protobuf.Timestamp", ".my_package.MyMessage".
+	//
+	// Note: this is the historical representation of fully-qualified Protobuf names,
+	// where a leading dot denotes an absolute reference. Modern Protobuf does not use
+	// the leading dot, and most fully-qualified names are represented without it. Most
+	// users will want to use `protobuf_fqn` instead.
+	//
+	// If the field value isn't a valid fully-qualified Protobuf name with a leading dot,
+	// an error message will be generated.
+	//
+	// ```proto
+	//
+	//	message MyString {
+	//	  // value must be a valid fully-qualified Protobuf name with a leading dot
+	//	  string value = 1 [(buf.validate.field).string.protobuf_dot_fqn = true];
+	//	}
+	//
+	// ```
+	ProtobufDotFqn bool `protobuf:"varint,38,opt,name=protobuf_dot_fqn,json=protobufDotFqn,oneof"`
 }
 
 type StringRules_WellKnownRegex struct {
@@ -5552,7 +5632,7 @@ type StringRules_WellKnownRegex struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	  // value must be a valid HTTP header value
+	//	  // must be a valid HTTP header value
 	//	  string value = 1 [(buf.validate.field).string.well_known_regex = KNOWN_REGEX_HTTP_HEADER_VALUE];
 	//	}
 	//
@@ -5606,6 +5686,10 @@ func (*StringRules_HostAndPort) isStringRules_WellKnown() {}
 
 func (*StringRules_Ulid) isStringRules_WellKnown() {}
 
+func (*StringRules_ProtobufFqn) isStringRules_WellKnown() {}
+
+func (*StringRules_ProtobufDotFqn) isStringRules_WellKnown() {}
+
 func (*StringRules_WellKnownRegex) isStringRules_WellKnown() {}
 
 // BytesRules describe the rules applied to `bytes` values. These rules
@@ -5618,7 +5702,7 @@ type BytesRules struct {
 	// ```proto
 	//
 	//	message MyBytes {
-	//	  // value must be "\x01\x02\x03\x04"
+	//	  // must be "\x01\x02\x03\x04"
 	//	  bytes value = 1 [(buf.validate.field).bytes.const = "\x01\x02\x03\x04"];
 	//	}
 	//
@@ -5656,7 +5740,7 @@ type BytesRules struct {
 	// ```proto
 	//
 	//	message MyBytes {
-	//	  // value must be at most 6 bytes.
+	//	  // must be at most 6 bytes.
 	//	  optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
 	//	}
 	//
@@ -5934,7 +6018,7 @@ type BytesRules_Ip struct {
 	// ```proto
 	//
 	//	message MyBytes {
-	//	  // value must be a valid IP address
+	//	  // must be a valid IP address
 	//	  optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
 	//	}
 	//
@@ -5949,7 +6033,7 @@ type BytesRules_Ipv4 struct {
 	// ```proto
 	//
 	//	message MyBytes {
-	//	  // value must be a valid IPv4 address
+	//	  // must be a valid IPv4 address
 	//	  optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
 	//	}
 	//
@@ -5963,7 +6047,7 @@ type BytesRules_Ipv6 struct {
 	// ```proto
 	//
 	//	message MyBytes {
-	//	  // value must be a valid IPv6 address
+	//	  // must be a valid IPv6 address
 	//	  optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
 	//	}
 	//
@@ -5972,16 +6056,15 @@ type BytesRules_Ipv6 struct {
 }
 
 type BytesRules_Uuid struct {
-	// `uuid` ensures that the field `value` encodes the 128-bit UUID data as
-	// defined by [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.2).
-	// The field must contain exactly 16 bytes
-	// representing the UUID. If the field value isn't a valid UUID, an error
-	// message will be generated.
+	// `uuid` ensures that the field value encodes 128-bit UUID data as defined
+	// by [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.2).
+	// The field must contain exactly 16 bytes representing the UUID. If the
+	// field value isn't a valid UUID, an error message will be generated.
 	//
 	// ```proto
 	//
 	//	message MyBytes {
-	//	  // value must be a valid UUID
+	//	  // must be a valid UUID
 	//	  optional bytes value = 1 [(buf.validate.field).bytes.uuid = true];
 	//	}
 	//
@@ -6436,7 +6519,7 @@ type AnyRules struct {
 	//
 	// ```
 	In []string `protobuf:"bytes,2,rep,name=in" json:"in,omitempty"`
-	// requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
+	// `not_in` requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
 	//
 	// ```proto
 	//
@@ -6530,7 +6613,7 @@ type DurationRules struct {
 	// ```proto
 	//
 	//	message MyDuration {
-	//	  // value must be in list [1s, 2s, 3s]
+	//	  // must be in list [1s, 2s, 3s]
 	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
 	//	}
 	//
@@ -6690,7 +6773,7 @@ type DurationRules_Lt struct {
 	// ```proto
 	//
 	//	message MyDuration {
-	//	  // value must be less than 5s
+	//	  // must be less than 5s
 	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
 	//	}
 	//
@@ -6706,7 +6789,7 @@ type DurationRules_Lte struct {
 	// ```proto
 	//
 	//	message MyDuration {
-	//	  // value must be less than or equal to 10s
+	//	  // must be less than or equal to 10s
 	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
 	//	}
 	//
@@ -6935,7 +7018,7 @@ type TimestampRules struct {
 	// ```proto
 	//
 	//	message MyTimestamp {
-	//	  // value must be within 1 hour of now
+	//	  // must be within 1 hour of now
 	//	  google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
 	//	}
 	//
@@ -7085,13 +7168,13 @@ type isTimestampRules_LessThan interface {
 }
 
 type TimestampRules_Lt struct {
-	// requires the duration field value to be less than the specified value (field < value). If the field value doesn't meet the required conditions, an error message is generated.
+	// `lt` requires the timestamp field value to be less than the specified value (field < value). If the field value doesn't meet the required conditions, an error message is generated.
 	//
 	// ```proto
 	//
-	//	message MyDuration {
-	//	  // duration must be less than 'P3D' [duration.lt]
-	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = { seconds: 259200 }];
+	//	message MyTimestamp {
+	//	  // timestamp must be less than '2023-01-01T00:00:00Z' [timestamp.lt]
+	//	  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.lt = { seconds: 1672444800 }];
 	//	}
 	//
 	// ```
@@ -7099,7 +7182,7 @@ type TimestampRules_Lt struct {
 }
 
 type TimestampRules_Lte struct {
-	// requires the timestamp field value to be less than or equal to the specified value (field <= value). If the field value doesn't meet the required conditions, an error message is generated.
+	// `lte` requires the timestamp field value to be less than or equal to the specified value (field <= value). If the field value doesn't meet the required conditions, an error message is generated.
 	//
 	// ```proto
 	//
@@ -7118,7 +7201,7 @@ type TimestampRules_LtNow struct {
 	// ```proto
 	//
 	//	message MyTimestamp {
-	//	 // value must be less than now
+	//	 // must be less than now
 	//	  google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
 	//	}
 	//
@@ -7190,7 +7273,7 @@ type TimestampRules_GtNow struct {
 	// ```proto
 	//
 	//	message MyTimestamp {
-	//	  // value must be greater than now
+	//	  // must be greater than now
 	//	  google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
 	//	}
 	//
@@ -7753,7 +7836,7 @@ var (
 	//	extend buf.validate.Int32Rules {
 	//	  bool is_zero [(buf.validate.predefined).cel = {
 	//	    id: "int32.is_zero",
-	//	    message: "value must be zero",
+	//	    message: "must be zero",
 	//	    expression: "!rule || this == 0",
 	//	  }];
 	//	}
@@ -7822,788 +7905,798 @@ const file_buf_validate_validate_proto_rawDesc = "" +
 	"\ttimestamp\x18\x16 \x01(\v2\x1c.buf.validate.TimestampRulesH\x00R\ttimestampB\x06\n" +
 	"\x04typeJ\x04\b\x18\x10\x19J\x04\b\x1a\x10\x1bR\askippedR\fignore_empty\"Z\n" +
 	"\x0fPredefinedRules\x12$\n" +
-	"\x03cel\x18\x01 \x03(\v2\x12.buf.validate.RuleR\x03celJ\x04\b\x18\x10\x19J\x04\b\x1a\x10\x1bR\askippedR\fignore_empty\"\x90\x18\n" +
+	"\x03cel\x18\x01 \x03(\v2\x12.buf.validate.RuleR\x03celJ\x04\b\x18\x10\x19J\x04\b\x1a\x10\x1bR\askippedR\fignore_empty\"\xae\x17\n" +
 	"\n" +
-	"FloatRules\x12\x8a\x01\n" +
-	"\x05const\x18\x01 \x01(\x02Bt\xc2Hq\n" +
-	"o\n" +
-	"\vfloat.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\xa3\x01\n" +
-	"\x02lt\x18\x02 \x01(\x02B\x90\x01\xc2H\x8c\x01\n" +
-	"\x89\x01\n" +
-	"\bfloat.lt\x1a}!has(rules.gte) && !has(rules.gt) && (this.isNan() || this >= rules.lt)? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xb4\x01\n" +
-	"\x03lte\x18\x03 \x01(\x02B\x9f\x01\xc2H\x9b\x01\n" +
-	"\x98\x01\n" +
-	"\tfloat.lte\x1a\x8a\x01!has(rules.gte) && !has(rules.gt) && (this.isNan() || this > rules.lte)? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xf3\a\n" +
-	"\x02gt\x18\x04 \x01(\x02B\xe0\a\xc2H\xdc\a\n" +
-	"\x8d\x01\n" +
-	"\bfloat.gt\x1a\x80\x01!has(rules.lt) && !has(rules.lte) && (this.isNan() || this <= rules.gt)? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xc3\x01\n" +
-	"\vfloat.gt_lt\x1a\xb3\x01has(rules.lt) && rules.lt >= rules.gt && (this.isNan() || this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"FloatRules\x12\x84\x01\n" +
+	"\x05const\x18\x01 \x01(\x02Bn\xc2Hk\n" +
+	"i\n" +
+	"\vfloat.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x9d\x01\n" +
+	"\x02lt\x18\x02 \x01(\x02B\x8a\x01\xc2H\x86\x01\n" +
+	"\x83\x01\n" +
+	"\bfloat.lt\x1aw!has(rules.gte) && !has(rules.gt) && (this.isNan() || this >= rules.lt)? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xae\x01\n" +
+	"\x03lte\x18\x03 \x01(\x02B\x99\x01\xc2H\x95\x01\n" +
+	"\x92\x01\n" +
+	"\tfloat.lte\x1a\x84\x01!has(rules.gte) && !has(rules.gt) && (this.isNan() || this > rules.lte)? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xd4\a\n" +
+	"\x02gt\x18\x04 \x01(\x02B\xc1\a\xc2H\xbd\a\n" +
+	"\x86\x01\n" +
+	"\bfloat.gt\x1az!has(rules.lt) && !has(rules.lte) && (this.isNan() || this <= rules.gt)? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xbd\x01\n" +
+	"\vfloat.gt_lt\x1a\xad\x01has(rules.lt) && rules.lt >= rules.gt && (this.isNan() || this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xc7\x01\n" +
+	"\x15float.gt_lt_exclusive\x1a\xad\x01has(rules.lt) && rules.lt < rules.gt && (this.isNan() || (rules.lt <= this && this <= rules.gt))? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
 	"\xcd\x01\n" +
-	"\x15float.gt_lt_exclusive\x1a\xb3\x01has(rules.lt) && rules.lt < rules.gt && (this.isNan() || (rules.lt <= this && this <= rules.gt))? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xd3\x01\n" +
-	"\ffloat.gt_lte\x1a\xc2\x01has(rules.lte) && rules.lte >= rules.gt && (this.isNan() || this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xdd\x01\n" +
-	"\x16float.gt_lte_exclusive\x1a\xc2\x01has(rules.lte) && rules.lte < rules.gt && (this.isNan() || (rules.lte < this && this <= rules.gt))? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xbf\b\n" +
-	"\x03gte\x18\x05 \x01(\x02B\xaa\b\xc2H\xa6\b\n" +
-	"\x9b\x01\n" +
-	"\tfloat.gte\x1a\x8d\x01!has(rules.lt) && !has(rules.lte) && (this.isNan() || this < rules.gte)? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xd2\x01\n" +
-	"\ffloat.gte_lt\x1a\xc1\x01has(rules.lt) && rules.lt >= rules.gte && (this.isNan() || this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\ffloat.gt_lte\x1a\xbc\x01has(rules.lte) && rules.lte >= rules.gt && (this.isNan() || this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xd7\x01\n" +
+	"\x16float.gt_lte_exclusive\x1a\xbc\x01has(rules.lte) && rules.lte < rules.gt && (this.isNan() || (rules.lte < this && this <= rules.gt))? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xa1\b\n" +
+	"\x03gte\x18\x05 \x01(\x02B\x8c\b\xc2H\x88\b\n" +
+	"\x95\x01\n" +
+	"\tfloat.gte\x1a\x87\x01!has(rules.lt) && !has(rules.lte) && (this.isNan() || this < rules.gte)? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xcc\x01\n" +
+	"\ffloat.gte_lt\x1a\xbb\x01has(rules.lt) && rules.lt >= rules.gte && (this.isNan() || this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xd6\x01\n" +
+	"\x16float.gte_lt_exclusive\x1a\xbb\x01has(rules.lt) && rules.lt < rules.gte && (this.isNan() || (rules.lt <= this && this < rules.gte))? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
 	"\xdc\x01\n" +
-	"\x16float.gte_lt_exclusive\x1a\xc1\x01has(rules.lt) && rules.lt < rules.gte && (this.isNan() || (rules.lt <= this && this < rules.gte))? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xe2\x01\n" +
-	"\rfloat.gte_lte\x1a\xd0\x01has(rules.lte) && rules.lte >= rules.gte && (this.isNan() || this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xec\x01\n" +
-	"\x17float.gte_lte_exclusive\x1a\xd0\x01has(rules.lte) && rules.lte < rules.gte && (this.isNan() || (rules.lte < this && this < rules.gte))? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x83\x01\n" +
-	"\x02in\x18\x06 \x03(\x02Bs\xc2Hp\n" +
-	"n\n" +
-	"\bfloat.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12}\n" +
-	"\x06not_in\x18\a \x03(\x02Bf\xc2Hc\n" +
-	"a\n" +
-	"\ffloat.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12}\n" +
-	"\x06finite\x18\b \x01(\bBe\xc2Hb\n" +
-	"`\n" +
-	"\ffloat.finite\x1aPrules.finite ? (this.isNan() || this.isInf() ? 'value must be finite' : '') : ''R\x06finite\x124\n" +
+	"\rfloat.gte_lte\x1a\xca\x01has(rules.lte) && rules.lte >= rules.gte && (this.isNan() || this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xe6\x01\n" +
+	"\x17float.gte_lte_exclusive\x1a\xca\x01has(rules.lte) && rules.lte < rules.gte && (this.isNan() || (rules.lte < this && this < rules.gte))? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12}\n" +
+	"\x02in\x18\x06 \x03(\x02Bm\xc2Hj\n" +
+	"h\n" +
+	"\bfloat.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12w\n" +
+	"\x06not_in\x18\a \x03(\x02B`\xc2H]\n" +
+	"[\n" +
+	"\ffloat.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12w\n" +
+	"\x06finite\x18\b \x01(\bB_\xc2H\\\n" +
+	"Z\n" +
+	"\ffloat.finite\x1aJrules.finite ? (this.isNan() || this.isInf() ? 'must be finite' : '') : ''R\x06finite\x124\n" +
 	"\aexample\x18\t \x03(\x02B\x1a\xc2H\x17\n" +
 	"\x15\n" +
 	"\rfloat.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xa2\x18\n" +
-	"\vDoubleRules\x12\x8b\x01\n" +
-	"\x05const\x18\x01 \x01(\x01Bu\xc2Hr\n" +
-	"p\n" +
-	"\fdouble.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\xa4\x01\n" +
-	"\x02lt\x18\x02 \x01(\x01B\x91\x01\xc2H\x8d\x01\n" +
-	"\x8a\x01\n" +
-	"\tdouble.lt\x1a}!has(rules.gte) && !has(rules.gt) && (this.isNan() || this >= rules.lt)? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xb5\x01\n" +
-	"\x03lte\x18\x03 \x01(\x01B\xa0\x01\xc2H\x9c\x01\n" +
-	"\x99\x01\n" +
+	"\fgreater_than\"\xc0\x17\n" +
+	"\vDoubleRules\x12\x85\x01\n" +
+	"\x05const\x18\x01 \x01(\x01Bo\xc2Hl\n" +
+	"j\n" +
+	"\fdouble.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x9e\x01\n" +
+	"\x02lt\x18\x02 \x01(\x01B\x8b\x01\xc2H\x87\x01\n" +
+	"\x84\x01\n" +
+	"\tdouble.lt\x1aw!has(rules.gte) && !has(rules.gt) && (this.isNan() || this >= rules.lt)? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xaf\x01\n" +
+	"\x03lte\x18\x03 \x01(\x01B\x9a\x01\xc2H\x96\x01\n" +
+	"\x93\x01\n" +
 	"\n" +
-	"double.lte\x1a\x8a\x01!has(rules.gte) && !has(rules.gt) && (this.isNan() || this > rules.lte)? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xf8\a\n" +
-	"\x02gt\x18\x04 \x01(\x01B\xe5\a\xc2H\xe1\a\n" +
-	"\x8e\x01\n" +
-	"\tdouble.gt\x1a\x80\x01!has(rules.lt) && !has(rules.lte) && (this.isNan() || this <= rules.gt)? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xc4\x01\n" +
-	"\fdouble.gt_lt\x1a\xb3\x01has(rules.lt) && rules.lt >= rules.gt && (this.isNan() || this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"double.lte\x1a\x84\x01!has(rules.gte) && !has(rules.gt) && (this.isNan() || this > rules.lte)? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xd9\a\n" +
+	"\x02gt\x18\x04 \x01(\x01B\xc6\a\xc2H\xc2\a\n" +
+	"\x87\x01\n" +
+	"\tdouble.gt\x1az!has(rules.lt) && !has(rules.lte) && (this.isNan() || this <= rules.gt)? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xbe\x01\n" +
+	"\fdouble.gt_lt\x1a\xad\x01has(rules.lt) && rules.lt >= rules.gt && (this.isNan() || this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xc8\x01\n" +
+	"\x16double.gt_lt_exclusive\x1a\xad\x01has(rules.lt) && rules.lt < rules.gt && (this.isNan() || (rules.lt <= this && this <= rules.gt))? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
 	"\xce\x01\n" +
-	"\x16double.gt_lt_exclusive\x1a\xb3\x01has(rules.lt) && rules.lt < rules.gt && (this.isNan() || (rules.lt <= this && this <= rules.gt))? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xd4\x01\n" +
-	"\rdouble.gt_lte\x1a\xc2\x01has(rules.lte) && rules.lte >= rules.gt && (this.isNan() || this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xde\x01\n" +
-	"\x17double.gt_lte_exclusive\x1a\xc2\x01has(rules.lte) && rules.lte < rules.gt && (this.isNan() || (rules.lte < this && this <= rules.gt))? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xc4\b\n" +
-	"\x03gte\x18\x05 \x01(\x01B\xaf\b\xc2H\xab\b\n" +
-	"\x9c\x01\n" +
+	"\rdouble.gt_lte\x1a\xbc\x01has(rules.lte) && rules.lte >= rules.gt && (this.isNan() || this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xd8\x01\n" +
+	"\x17double.gt_lte_exclusive\x1a\xbc\x01has(rules.lte) && rules.lte < rules.gt && (this.isNan() || (rules.lte < this && this <= rules.gt))? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xa6\b\n" +
+	"\x03gte\x18\x05 \x01(\x01B\x91\b\xc2H\x8d\b\n" +
+	"\x96\x01\n" +
 	"\n" +
-	"double.gte\x1a\x8d\x01!has(rules.lt) && !has(rules.lte) && (this.isNan() || this < rules.gte)? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xd3\x01\n" +
-	"\rdouble.gte_lt\x1a\xc1\x01has(rules.lt) && rules.lt >= rules.gte && (this.isNan() || this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"double.gte\x1a\x87\x01!has(rules.lt) && !has(rules.lte) && (this.isNan() || this < rules.gte)? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xcd\x01\n" +
+	"\rdouble.gte_lt\x1a\xbb\x01has(rules.lt) && rules.lt >= rules.gte && (this.isNan() || this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xd7\x01\n" +
+	"\x17double.gte_lt_exclusive\x1a\xbb\x01has(rules.lt) && rules.lt < rules.gte && (this.isNan() || (rules.lt <= this && this < rules.gte))? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
 	"\xdd\x01\n" +
-	"\x17double.gte_lt_exclusive\x1a\xc1\x01has(rules.lt) && rules.lt < rules.gte && (this.isNan() || (rules.lt <= this && this < rules.gte))? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xe3\x01\n" +
-	"\x0edouble.gte_lte\x1a\xd0\x01has(rules.lte) && rules.lte >= rules.gte && (this.isNan() || this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xed\x01\n" +
-	"\x18double.gte_lte_exclusive\x1a\xd0\x01has(rules.lte) && rules.lte < rules.gte && (this.isNan() || (rules.lte < this && this < rules.gte))? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x84\x01\n" +
-	"\x02in\x18\x06 \x03(\x01Bt\xc2Hq\n" +
-	"o\n" +
-	"\tdouble.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12~\n" +
-	"\x06not_in\x18\a \x03(\x01Bg\xc2Hd\n" +
-	"b\n" +
-	"\rdouble.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12~\n" +
-	"\x06finite\x18\b \x01(\bBf\xc2Hc\n" +
-	"a\n" +
-	"\rdouble.finite\x1aPrules.finite ? (this.isNan() || this.isInf() ? 'value must be finite' : '') : ''R\x06finite\x125\n" +
+	"\x0edouble.gte_lte\x1a\xca\x01has(rules.lte) && rules.lte >= rules.gte && (this.isNan() || this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xe7\x01\n" +
+	"\x18double.gte_lte_exclusive\x1a\xca\x01has(rules.lte) && rules.lte < rules.gte && (this.isNan() || (rules.lte < this && this < rules.gte))? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12~\n" +
+	"\x02in\x18\x06 \x03(\x01Bn\xc2Hk\n" +
+	"i\n" +
+	"\tdouble.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12x\n" +
+	"\x06not_in\x18\a \x03(\x01Ba\xc2H^\n" +
+	"\\\n" +
+	"\rdouble.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12x\n" +
+	"\x06finite\x18\b \x01(\bB`\xc2H]\n" +
+	"[\n" +
+	"\rdouble.finite\x1aJrules.finite ? (this.isNan() || this.isInf() ? 'must be finite' : '') : ''R\x06finite\x125\n" +
 	"\aexample\x18\t \x03(\x01B\x1b\xc2H\x18\n" +
 	"\x16\n" +
 	"\x0edouble.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xba\x15\n" +
+	"\fgreater_than\"\xde\x14\n" +
 	"\n" +
-	"Int32Rules\x12\x8a\x01\n" +
-	"\x05const\x18\x01 \x01(\x05Bt\xc2Hq\n" +
-	"o\n" +
-	"\vint32.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8e\x01\n" +
-	"\x02lt\x18\x02 \x01(\x05B|\xc2Hy\n" +
-	"w\n" +
-	"\bint32.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa1\x01\n" +
-	"\x03lte\x18\x03 \x01(\x05B\x8c\x01\xc2H\x88\x01\n" +
-	"\x85\x01\n" +
-	"\tint32.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x9b\a\n" +
-	"\x02gt\x18\x04 \x01(\x05B\x88\a\xc2H\x84\a\n" +
-	"z\n" +
-	"\bint32.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb3\x01\n" +
-	"\vint32.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbb\x01\n" +
-	"\x15int32.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc3\x01\n" +
-	"\fint32.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xcb\x01\n" +
-	"\x16int32.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xe8\a\n" +
-	"\x03gte\x18\x05 \x01(\x05B\xd3\a\xc2H\xcf\a\n" +
-	"\x88\x01\n" +
-	"\tint32.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc2\x01\n" +
-	"\fint32.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xca\x01\n" +
-	"\x16int32.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd2\x01\n" +
-	"\rint32.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xda\x01\n" +
-	"\x17int32.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x83\x01\n" +
-	"\x02in\x18\x06 \x03(\x05Bs\xc2Hp\n" +
-	"n\n" +
-	"\bint32.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12}\n" +
-	"\x06not_in\x18\a \x03(\x05Bf\xc2Hc\n" +
-	"a\n" +
-	"\fint32.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x124\n" +
+	"Int32Rules\x12\x84\x01\n" +
+	"\x05const\x18\x01 \x01(\x05Bn\xc2Hk\n" +
+	"i\n" +
+	"\vint32.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x88\x01\n" +
+	"\x02lt\x18\x02 \x01(\x05Bv\xc2Hs\n" +
+	"q\n" +
+	"\bint32.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9a\x01\n" +
+	"\x03lte\x18\x03 \x01(\x05B\x85\x01\xc2H\x81\x01\n" +
+	"\x7f\n" +
+	"\tint32.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xfd\x06\n" +
+	"\x02gt\x18\x04 \x01(\x05B\xea\x06\xc2H\xe6\x06\n" +
+	"t\n" +
+	"\bint32.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xad\x01\n" +
+	"\vint32.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb5\x01\n" +
+	"\x15int32.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xbd\x01\n" +
+	"\fint32.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc5\x01\n" +
+	"\x16int32.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xca\a\n" +
+	"\x03gte\x18\x05 \x01(\x05B\xb5\a\xc2H\xb1\a\n" +
+	"\x82\x01\n" +
+	"\tint32.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbc\x01\n" +
+	"\fint32.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc4\x01\n" +
+	"\x16int32.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xcc\x01\n" +
+	"\rint32.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd4\x01\n" +
+	"\x17int32.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12}\n" +
+	"\x02in\x18\x06 \x03(\x05Bm\xc2Hj\n" +
+	"h\n" +
+	"\bint32.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12w\n" +
+	"\x06not_in\x18\a \x03(\x05B`\xc2H]\n" +
+	"[\n" +
+	"\fint32.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x124\n" +
 	"\aexample\x18\b \x03(\x05B\x1a\xc2H\x17\n" +
 	"\x15\n" +
 	"\rint32.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xba\x15\n" +
+	"\fgreater_than\"\xde\x14\n" +
 	"\n" +
-	"Int64Rules\x12\x8a\x01\n" +
-	"\x05const\x18\x01 \x01(\x03Bt\xc2Hq\n" +
-	"o\n" +
-	"\vint64.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8e\x01\n" +
-	"\x02lt\x18\x02 \x01(\x03B|\xc2Hy\n" +
-	"w\n" +
-	"\bint64.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa1\x01\n" +
-	"\x03lte\x18\x03 \x01(\x03B\x8c\x01\xc2H\x88\x01\n" +
-	"\x85\x01\n" +
-	"\tint64.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x9b\a\n" +
-	"\x02gt\x18\x04 \x01(\x03B\x88\a\xc2H\x84\a\n" +
-	"z\n" +
-	"\bint64.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb3\x01\n" +
-	"\vint64.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbb\x01\n" +
-	"\x15int64.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc3\x01\n" +
-	"\fint64.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xcb\x01\n" +
-	"\x16int64.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xe8\a\n" +
-	"\x03gte\x18\x05 \x01(\x03B\xd3\a\xc2H\xcf\a\n" +
-	"\x88\x01\n" +
-	"\tint64.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc2\x01\n" +
-	"\fint64.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xca\x01\n" +
-	"\x16int64.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd2\x01\n" +
-	"\rint64.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xda\x01\n" +
-	"\x17int64.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x83\x01\n" +
-	"\x02in\x18\x06 \x03(\x03Bs\xc2Hp\n" +
-	"n\n" +
-	"\bint64.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12}\n" +
-	"\x06not_in\x18\a \x03(\x03Bf\xc2Hc\n" +
-	"a\n" +
-	"\fint64.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x124\n" +
+	"Int64Rules\x12\x84\x01\n" +
+	"\x05const\x18\x01 \x01(\x03Bn\xc2Hk\n" +
+	"i\n" +
+	"\vint64.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x88\x01\n" +
+	"\x02lt\x18\x02 \x01(\x03Bv\xc2Hs\n" +
+	"q\n" +
+	"\bint64.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9a\x01\n" +
+	"\x03lte\x18\x03 \x01(\x03B\x85\x01\xc2H\x81\x01\n" +
+	"\x7f\n" +
+	"\tint64.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xfd\x06\n" +
+	"\x02gt\x18\x04 \x01(\x03B\xea\x06\xc2H\xe6\x06\n" +
+	"t\n" +
+	"\bint64.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xad\x01\n" +
+	"\vint64.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb5\x01\n" +
+	"\x15int64.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xbd\x01\n" +
+	"\fint64.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc5\x01\n" +
+	"\x16int64.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xca\a\n" +
+	"\x03gte\x18\x05 \x01(\x03B\xb5\a\xc2H\xb1\a\n" +
+	"\x82\x01\n" +
+	"\tint64.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbc\x01\n" +
+	"\fint64.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc4\x01\n" +
+	"\x16int64.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xcc\x01\n" +
+	"\rint64.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd4\x01\n" +
+	"\x17int64.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12}\n" +
+	"\x02in\x18\x06 \x03(\x03Bm\xc2Hj\n" +
+	"h\n" +
+	"\bint64.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12w\n" +
+	"\x06not_in\x18\a \x03(\x03B`\xc2H]\n" +
+	"[\n" +
+	"\fint64.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x124\n" +
 	"\aexample\x18\t \x03(\x03B\x1a\xc2H\x17\n" +
 	"\x15\n" +
 	"\rint64.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xcb\x15\n" +
-	"\vUInt32Rules\x12\x8b\x01\n" +
-	"\x05const\x18\x01 \x01(\rBu\xc2Hr\n" +
-	"p\n" +
-	"\fuint32.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8f\x01\n" +
-	"\x02lt\x18\x02 \x01(\rB}\xc2Hz\n" +
-	"x\n" +
-	"\tuint32.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa2\x01\n" +
-	"\x03lte\x18\x03 \x01(\rB\x8d\x01\xc2H\x89\x01\n" +
-	"\x86\x01\n" +
+	"\fgreater_than\"\xf0\x14\n" +
+	"\vUInt32Rules\x12\x85\x01\n" +
+	"\x05const\x18\x01 \x01(\rBo\xc2Hl\n" +
+	"j\n" +
+	"\fuint32.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x89\x01\n" +
+	"\x02lt\x18\x02 \x01(\rBw\xc2Ht\n" +
+	"r\n" +
+	"\tuint32.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9c\x01\n" +
+	"\x03lte\x18\x03 \x01(\rB\x87\x01\xc2H\x83\x01\n" +
+	"\x80\x01\n" +
 	"\n" +
-	"uint32.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xa0\a\n" +
-	"\x02gt\x18\x04 \x01(\rB\x8d\a\xc2H\x89\a\n" +
-	"{\n" +
-	"\tuint32.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb4\x01\n" +
-	"\fuint32.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbc\x01\n" +
-	"\x16uint32.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc4\x01\n" +
-	"\ruint32.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xcc\x01\n" +
-	"\x17uint32.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xed\a\n" +
-	"\x03gte\x18\x05 \x01(\rB\xd8\a\xc2H\xd4\a\n" +
-	"\x89\x01\n" +
+	"uint32.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x82\a\n" +
+	"\x02gt\x18\x04 \x01(\rB\xef\x06\xc2H\xeb\x06\n" +
+	"u\n" +
+	"\tuint32.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xae\x01\n" +
+	"\fuint32.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb6\x01\n" +
+	"\x16uint32.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xbe\x01\n" +
+	"\ruint32.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc6\x01\n" +
+	"\x17uint32.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xcf\a\n" +
+	"\x03gte\x18\x05 \x01(\rB\xba\a\xc2H\xb6\a\n" +
+	"\x83\x01\n" +
 	"\n" +
-	"uint32.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc3\x01\n" +
-	"\ruint32.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xcb\x01\n" +
-	"\x17uint32.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd3\x01\n" +
-	"\x0euint32.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xdb\x01\n" +
-	"\x18uint32.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x84\x01\n" +
-	"\x02in\x18\x06 \x03(\rBt\xc2Hq\n" +
-	"o\n" +
-	"\tuint32.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12~\n" +
-	"\x06not_in\x18\a \x03(\rBg\xc2Hd\n" +
-	"b\n" +
-	"\ruint32.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x125\n" +
+	"uint32.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbd\x01\n" +
+	"\ruint32.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc5\x01\n" +
+	"\x17uint32.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xcd\x01\n" +
+	"\x0euint32.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd5\x01\n" +
+	"\x18uint32.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12~\n" +
+	"\x02in\x18\x06 \x03(\rBn\xc2Hk\n" +
+	"i\n" +
+	"\tuint32.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12x\n" +
+	"\x06not_in\x18\a \x03(\rBa\xc2H^\n" +
+	"\\\n" +
+	"\ruint32.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x125\n" +
 	"\aexample\x18\b \x03(\rB\x1b\xc2H\x18\n" +
 	"\x16\n" +
 	"\x0euint32.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xcb\x15\n" +
-	"\vUInt64Rules\x12\x8b\x01\n" +
-	"\x05const\x18\x01 \x01(\x04Bu\xc2Hr\n" +
-	"p\n" +
-	"\fuint64.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8f\x01\n" +
-	"\x02lt\x18\x02 \x01(\x04B}\xc2Hz\n" +
-	"x\n" +
-	"\tuint64.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa2\x01\n" +
-	"\x03lte\x18\x03 \x01(\x04B\x8d\x01\xc2H\x89\x01\n" +
-	"\x86\x01\n" +
+	"\fgreater_than\"\xf0\x14\n" +
+	"\vUInt64Rules\x12\x85\x01\n" +
+	"\x05const\x18\x01 \x01(\x04Bo\xc2Hl\n" +
+	"j\n" +
+	"\fuint64.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x89\x01\n" +
+	"\x02lt\x18\x02 \x01(\x04Bw\xc2Ht\n" +
+	"r\n" +
+	"\tuint64.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9c\x01\n" +
+	"\x03lte\x18\x03 \x01(\x04B\x87\x01\xc2H\x83\x01\n" +
+	"\x80\x01\n" +
 	"\n" +
-	"uint64.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xa0\a\n" +
-	"\x02gt\x18\x04 \x01(\x04B\x8d\a\xc2H\x89\a\n" +
-	"{\n" +
-	"\tuint64.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb4\x01\n" +
-	"\fuint64.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbc\x01\n" +
-	"\x16uint64.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc4\x01\n" +
-	"\ruint64.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xcc\x01\n" +
-	"\x17uint64.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xed\a\n" +
-	"\x03gte\x18\x05 \x01(\x04B\xd8\a\xc2H\xd4\a\n" +
-	"\x89\x01\n" +
+	"uint64.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x82\a\n" +
+	"\x02gt\x18\x04 \x01(\x04B\xef\x06\xc2H\xeb\x06\n" +
+	"u\n" +
+	"\tuint64.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xae\x01\n" +
+	"\fuint64.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb6\x01\n" +
+	"\x16uint64.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xbe\x01\n" +
+	"\ruint64.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc6\x01\n" +
+	"\x17uint64.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xcf\a\n" +
+	"\x03gte\x18\x05 \x01(\x04B\xba\a\xc2H\xb6\a\n" +
+	"\x83\x01\n" +
 	"\n" +
-	"uint64.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc3\x01\n" +
-	"\ruint64.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xcb\x01\n" +
-	"\x17uint64.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd3\x01\n" +
-	"\x0euint64.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xdb\x01\n" +
-	"\x18uint64.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x84\x01\n" +
-	"\x02in\x18\x06 \x03(\x04Bt\xc2Hq\n" +
-	"o\n" +
-	"\tuint64.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12~\n" +
-	"\x06not_in\x18\a \x03(\x04Bg\xc2Hd\n" +
-	"b\n" +
-	"\ruint64.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x125\n" +
+	"uint64.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbd\x01\n" +
+	"\ruint64.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc5\x01\n" +
+	"\x17uint64.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xcd\x01\n" +
+	"\x0euint64.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd5\x01\n" +
+	"\x18uint64.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12~\n" +
+	"\x02in\x18\x06 \x03(\x04Bn\xc2Hk\n" +
+	"i\n" +
+	"\tuint64.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12x\n" +
+	"\x06not_in\x18\a \x03(\x04Ba\xc2H^\n" +
+	"\\\n" +
+	"\ruint64.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x125\n" +
 	"\aexample\x18\b \x03(\x04B\x1b\xc2H\x18\n" +
 	"\x16\n" +
 	"\x0euint64.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xcb\x15\n" +
-	"\vSInt32Rules\x12\x8b\x01\n" +
-	"\x05const\x18\x01 \x01(\x11Bu\xc2Hr\n" +
-	"p\n" +
-	"\fsint32.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8f\x01\n" +
-	"\x02lt\x18\x02 \x01(\x11B}\xc2Hz\n" +
-	"x\n" +
-	"\tsint32.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa2\x01\n" +
-	"\x03lte\x18\x03 \x01(\x11B\x8d\x01\xc2H\x89\x01\n" +
-	"\x86\x01\n" +
+	"\fgreater_than\"\xf0\x14\n" +
+	"\vSInt32Rules\x12\x85\x01\n" +
+	"\x05const\x18\x01 \x01(\x11Bo\xc2Hl\n" +
+	"j\n" +
+	"\fsint32.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x89\x01\n" +
+	"\x02lt\x18\x02 \x01(\x11Bw\xc2Ht\n" +
+	"r\n" +
+	"\tsint32.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9c\x01\n" +
+	"\x03lte\x18\x03 \x01(\x11B\x87\x01\xc2H\x83\x01\n" +
+	"\x80\x01\n" +
 	"\n" +
-	"sint32.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xa0\a\n" +
-	"\x02gt\x18\x04 \x01(\x11B\x8d\a\xc2H\x89\a\n" +
-	"{\n" +
-	"\tsint32.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb4\x01\n" +
-	"\fsint32.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbc\x01\n" +
-	"\x16sint32.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc4\x01\n" +
-	"\rsint32.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xcc\x01\n" +
-	"\x17sint32.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xed\a\n" +
-	"\x03gte\x18\x05 \x01(\x11B\xd8\a\xc2H\xd4\a\n" +
-	"\x89\x01\n" +
+	"sint32.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x82\a\n" +
+	"\x02gt\x18\x04 \x01(\x11B\xef\x06\xc2H\xeb\x06\n" +
+	"u\n" +
+	"\tsint32.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xae\x01\n" +
+	"\fsint32.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb6\x01\n" +
+	"\x16sint32.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xbe\x01\n" +
+	"\rsint32.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc6\x01\n" +
+	"\x17sint32.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xcf\a\n" +
+	"\x03gte\x18\x05 \x01(\x11B\xba\a\xc2H\xb6\a\n" +
+	"\x83\x01\n" +
 	"\n" +
-	"sint32.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc3\x01\n" +
-	"\rsint32.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xcb\x01\n" +
-	"\x17sint32.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd3\x01\n" +
-	"\x0esint32.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xdb\x01\n" +
-	"\x18sint32.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x84\x01\n" +
-	"\x02in\x18\x06 \x03(\x11Bt\xc2Hq\n" +
-	"o\n" +
-	"\tsint32.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12~\n" +
-	"\x06not_in\x18\a \x03(\x11Bg\xc2Hd\n" +
-	"b\n" +
-	"\rsint32.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x125\n" +
+	"sint32.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbd\x01\n" +
+	"\rsint32.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc5\x01\n" +
+	"\x17sint32.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xcd\x01\n" +
+	"\x0esint32.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd5\x01\n" +
+	"\x18sint32.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12~\n" +
+	"\x02in\x18\x06 \x03(\x11Bn\xc2Hk\n" +
+	"i\n" +
+	"\tsint32.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12x\n" +
+	"\x06not_in\x18\a \x03(\x11Ba\xc2H^\n" +
+	"\\\n" +
+	"\rsint32.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x125\n" +
 	"\aexample\x18\b \x03(\x11B\x1b\xc2H\x18\n" +
 	"\x16\n" +
 	"\x0esint32.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xcb\x15\n" +
-	"\vSInt64Rules\x12\x8b\x01\n" +
-	"\x05const\x18\x01 \x01(\x12Bu\xc2Hr\n" +
-	"p\n" +
-	"\fsint64.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8f\x01\n" +
-	"\x02lt\x18\x02 \x01(\x12B}\xc2Hz\n" +
-	"x\n" +
-	"\tsint64.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa2\x01\n" +
-	"\x03lte\x18\x03 \x01(\x12B\x8d\x01\xc2H\x89\x01\n" +
-	"\x86\x01\n" +
+	"\fgreater_than\"\xf0\x14\n" +
+	"\vSInt64Rules\x12\x85\x01\n" +
+	"\x05const\x18\x01 \x01(\x12Bo\xc2Hl\n" +
+	"j\n" +
+	"\fsint64.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x89\x01\n" +
+	"\x02lt\x18\x02 \x01(\x12Bw\xc2Ht\n" +
+	"r\n" +
+	"\tsint64.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9c\x01\n" +
+	"\x03lte\x18\x03 \x01(\x12B\x87\x01\xc2H\x83\x01\n" +
+	"\x80\x01\n" +
 	"\n" +
-	"sint64.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xa0\a\n" +
-	"\x02gt\x18\x04 \x01(\x12B\x8d\a\xc2H\x89\a\n" +
-	"{\n" +
-	"\tsint64.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb4\x01\n" +
-	"\fsint64.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbc\x01\n" +
-	"\x16sint64.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc4\x01\n" +
-	"\rsint64.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xcc\x01\n" +
-	"\x17sint64.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xed\a\n" +
-	"\x03gte\x18\x05 \x01(\x12B\xd8\a\xc2H\xd4\a\n" +
-	"\x89\x01\n" +
+	"sint64.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x82\a\n" +
+	"\x02gt\x18\x04 \x01(\x12B\xef\x06\xc2H\xeb\x06\n" +
+	"u\n" +
+	"\tsint64.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xae\x01\n" +
+	"\fsint64.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb6\x01\n" +
+	"\x16sint64.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xbe\x01\n" +
+	"\rsint64.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc6\x01\n" +
+	"\x17sint64.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xcf\a\n" +
+	"\x03gte\x18\x05 \x01(\x12B\xba\a\xc2H\xb6\a\n" +
+	"\x83\x01\n" +
 	"\n" +
-	"sint64.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc3\x01\n" +
-	"\rsint64.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xcb\x01\n" +
-	"\x17sint64.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd3\x01\n" +
-	"\x0esint64.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xdb\x01\n" +
-	"\x18sint64.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x84\x01\n" +
-	"\x02in\x18\x06 \x03(\x12Bt\xc2Hq\n" +
-	"o\n" +
-	"\tsint64.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12~\n" +
-	"\x06not_in\x18\a \x03(\x12Bg\xc2Hd\n" +
-	"b\n" +
-	"\rsint64.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x125\n" +
+	"sint64.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbd\x01\n" +
+	"\rsint64.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc5\x01\n" +
+	"\x17sint64.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xcd\x01\n" +
+	"\x0esint64.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd5\x01\n" +
+	"\x18sint64.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12~\n" +
+	"\x02in\x18\x06 \x03(\x12Bn\xc2Hk\n" +
+	"i\n" +
+	"\tsint64.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12x\n" +
+	"\x06not_in\x18\a \x03(\x12Ba\xc2H^\n" +
+	"\\\n" +
+	"\rsint64.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x125\n" +
 	"\aexample\x18\b \x03(\x12B\x1b\xc2H\x18\n" +
 	"\x16\n" +
 	"\x0esint64.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xdc\x15\n" +
-	"\fFixed32Rules\x12\x8c\x01\n" +
-	"\x05const\x18\x01 \x01(\aBv\xc2Hs\n" +
-	"q\n" +
-	"\rfixed32.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x90\x01\n" +
-	"\x02lt\x18\x02 \x01(\aB~\xc2H{\n" +
-	"y\n" +
+	"\fgreater_than\"\x81\x15\n" +
+	"\fFixed32Rules\x12\x86\x01\n" +
+	"\x05const\x18\x01 \x01(\aBp\xc2Hm\n" +
+	"k\n" +
+	"\rfixed32.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8a\x01\n" +
+	"\x02lt\x18\x02 \x01(\aBx\xc2Hu\n" +
+	"s\n" +
 	"\n" +
-	"fixed32.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa3\x01\n" +
-	"\x03lte\x18\x03 \x01(\aB\x8e\x01\xc2H\x8a\x01\n" +
-	"\x87\x01\n" +
-	"\vfixed32.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xa5\a\n" +
-	"\x02gt\x18\x04 \x01(\aB\x92\a\xc2H\x8e\a\n" +
-	"|\n" +
+	"fixed32.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9d\x01\n" +
+	"\x03lte\x18\x03 \x01(\aB\x88\x01\xc2H\x84\x01\n" +
+	"\x81\x01\n" +
+	"\vfixed32.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x87\a\n" +
+	"\x02gt\x18\x04 \x01(\aB\xf4\x06\xc2H\xf0\x06\n" +
+	"v\n" +
 	"\n" +
-	"fixed32.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb5\x01\n" +
-	"\rfixed32.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbd\x01\n" +
-	"\x17fixed32.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc5\x01\n" +
-	"\x0efixed32.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xcd\x01\n" +
-	"\x18fixed32.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xf2\a\n" +
-	"\x03gte\x18\x05 \x01(\aB\xdd\a\xc2H\xd9\a\n" +
-	"\x8a\x01\n" +
-	"\vfixed32.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc4\x01\n" +
-	"\x0efixed32.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xcc\x01\n" +
-	"\x18fixed32.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd4\x01\n" +
-	"\x0ffixed32.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xdc\x01\n" +
-	"\x19fixed32.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x85\x01\n" +
-	"\x02in\x18\x06 \x03(\aBu\xc2Hr\n" +
-	"p\n" +
+	"fixed32.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xaf\x01\n" +
+	"\rfixed32.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb7\x01\n" +
+	"\x17fixed32.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xbf\x01\n" +
+	"\x0efixed32.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc7\x01\n" +
+	"\x18fixed32.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xd4\a\n" +
+	"\x03gte\x18\x05 \x01(\aB\xbf\a\xc2H\xbb\a\n" +
+	"\x84\x01\n" +
+	"\vfixed32.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbe\x01\n" +
+	"\x0efixed32.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc6\x01\n" +
+	"\x18fixed32.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xce\x01\n" +
+	"\x0ffixed32.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd6\x01\n" +
+	"\x19fixed32.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x7f\n" +
+	"\x02in\x18\x06 \x03(\aBo\xc2Hl\n" +
+	"j\n" +
 	"\n" +
-	"fixed32.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\x7f\n" +
-	"\x06not_in\x18\a \x03(\aBh\xc2He\n" +
-	"c\n" +
-	"\x0efixed32.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x126\n" +
+	"fixed32.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12y\n" +
+	"\x06not_in\x18\a \x03(\aBb\xc2H_\n" +
+	"]\n" +
+	"\x0efixed32.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x126\n" +
 	"\aexample\x18\b \x03(\aB\x1c\xc2H\x19\n" +
 	"\x17\n" +
 	"\x0ffixed32.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xdc\x15\n" +
-	"\fFixed64Rules\x12\x8c\x01\n" +
-	"\x05const\x18\x01 \x01(\x06Bv\xc2Hs\n" +
-	"q\n" +
-	"\rfixed64.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x90\x01\n" +
-	"\x02lt\x18\x02 \x01(\x06B~\xc2H{\n" +
-	"y\n" +
+	"\fgreater_than\"\x81\x15\n" +
+	"\fFixed64Rules\x12\x86\x01\n" +
+	"\x05const\x18\x01 \x01(\x06Bp\xc2Hm\n" +
+	"k\n" +
+	"\rfixed64.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8a\x01\n" +
+	"\x02lt\x18\x02 \x01(\x06Bx\xc2Hu\n" +
+	"s\n" +
 	"\n" +
-	"fixed64.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa3\x01\n" +
-	"\x03lte\x18\x03 \x01(\x06B\x8e\x01\xc2H\x8a\x01\n" +
-	"\x87\x01\n" +
-	"\vfixed64.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xa5\a\n" +
-	"\x02gt\x18\x04 \x01(\x06B\x92\a\xc2H\x8e\a\n" +
-	"|\n" +
+	"fixed64.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9d\x01\n" +
+	"\x03lte\x18\x03 \x01(\x06B\x88\x01\xc2H\x84\x01\n" +
+	"\x81\x01\n" +
+	"\vfixed64.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x87\a\n" +
+	"\x02gt\x18\x04 \x01(\x06B\xf4\x06\xc2H\xf0\x06\n" +
+	"v\n" +
 	"\n" +
-	"fixed64.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb5\x01\n" +
-	"\rfixed64.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbd\x01\n" +
-	"\x17fixed64.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc5\x01\n" +
-	"\x0efixed64.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xcd\x01\n" +
-	"\x18fixed64.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xf2\a\n" +
-	"\x03gte\x18\x05 \x01(\x06B\xdd\a\xc2H\xd9\a\n" +
-	"\x8a\x01\n" +
-	"\vfixed64.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc4\x01\n" +
-	"\x0efixed64.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xcc\x01\n" +
-	"\x18fixed64.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd4\x01\n" +
-	"\x0ffixed64.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xdc\x01\n" +
-	"\x19fixed64.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x85\x01\n" +
-	"\x02in\x18\x06 \x03(\x06Bu\xc2Hr\n" +
-	"p\n" +
+	"fixed64.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xaf\x01\n" +
+	"\rfixed64.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb7\x01\n" +
+	"\x17fixed64.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xbf\x01\n" +
+	"\x0efixed64.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc7\x01\n" +
+	"\x18fixed64.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xd4\a\n" +
+	"\x03gte\x18\x05 \x01(\x06B\xbf\a\xc2H\xbb\a\n" +
+	"\x84\x01\n" +
+	"\vfixed64.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbe\x01\n" +
+	"\x0efixed64.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc6\x01\n" +
+	"\x18fixed64.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xce\x01\n" +
+	"\x0ffixed64.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd6\x01\n" +
+	"\x19fixed64.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x7f\n" +
+	"\x02in\x18\x06 \x03(\x06Bo\xc2Hl\n" +
+	"j\n" +
 	"\n" +
-	"fixed64.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\x7f\n" +
-	"\x06not_in\x18\a \x03(\x06Bh\xc2He\n" +
-	"c\n" +
-	"\x0efixed64.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x126\n" +
+	"fixed64.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12y\n" +
+	"\x06not_in\x18\a \x03(\x06Bb\xc2H_\n" +
+	"]\n" +
+	"\x0efixed64.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x126\n" +
 	"\aexample\x18\b \x03(\x06B\x1c\xc2H\x19\n" +
 	"\x17\n" +
 	"\x0ffixed64.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xee\x15\n" +
-	"\rSFixed32Rules\x12\x8d\x01\n" +
-	"\x05const\x18\x01 \x01(\x0fBw\xc2Ht\n" +
-	"r\n" +
-	"\x0esfixed32.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x91\x01\n" +
-	"\x02lt\x18\x02 \x01(\x0fB\x7f\xc2H|\n" +
-	"z\n" +
-	"\vsfixed32.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa4\x01\n" +
-	"\x03lte\x18\x03 \x01(\x0fB\x8f\x01\xc2H\x8b\x01\n" +
-	"\x88\x01\n" +
-	"\fsfixed32.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xaa\a\n" +
-	"\x02gt\x18\x04 \x01(\x0fB\x97\a\xc2H\x93\a\n" +
-	"}\n" +
-	"\vsfixed32.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb6\x01\n" +
-	"\x0esfixed32.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbe\x01\n" +
-	"\x18sfixed32.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc6\x01\n" +
-	"\x0fsfixed32.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xce\x01\n" +
-	"\x19sfixed32.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xf7\a\n" +
-	"\x03gte\x18\x05 \x01(\x0fB\xe2\a\xc2H\xde\a\n" +
-	"\x8b\x01\n" +
-	"\fsfixed32.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc5\x01\n" +
-	"\x0fsfixed32.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xcd\x01\n" +
-	"\x19sfixed32.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd5\x01\n" +
-	"\x10sfixed32.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xdd\x01\n" +
-	"\x1asfixed32.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x86\x01\n" +
-	"\x02in\x18\x06 \x03(\x0fBv\xc2Hs\n" +
-	"q\n" +
-	"\vsfixed32.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\x80\x01\n" +
-	"\x06not_in\x18\a \x03(\x0fBi\xc2Hf\n" +
-	"d\n" +
-	"\x0fsfixed32.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x127\n" +
+	"\fgreater_than\"\x93\x15\n" +
+	"\rSFixed32Rules\x12\x87\x01\n" +
+	"\x05const\x18\x01 \x01(\x0fBq\xc2Hn\n" +
+	"l\n" +
+	"\x0esfixed32.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8b\x01\n" +
+	"\x02lt\x18\x02 \x01(\x0fBy\xc2Hv\n" +
+	"t\n" +
+	"\vsfixed32.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9e\x01\n" +
+	"\x03lte\x18\x03 \x01(\x0fB\x89\x01\xc2H\x85\x01\n" +
+	"\x82\x01\n" +
+	"\fsfixed32.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x8c\a\n" +
+	"\x02gt\x18\x04 \x01(\x0fB\xf9\x06\xc2H\xf5\x06\n" +
+	"w\n" +
+	"\vsfixed32.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xb0\x01\n" +
+	"\x0esfixed32.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb8\x01\n" +
+	"\x18sfixed32.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xc0\x01\n" +
+	"\x0fsfixed32.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc8\x01\n" +
+	"\x19sfixed32.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xd9\a\n" +
+	"\x03gte\x18\x05 \x01(\x0fB\xc4\a\xc2H\xc0\a\n" +
+	"\x85\x01\n" +
+	"\fsfixed32.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbf\x01\n" +
+	"\x0fsfixed32.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc7\x01\n" +
+	"\x19sfixed32.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xcf\x01\n" +
+	"\x10sfixed32.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd7\x01\n" +
+	"\x1asfixed32.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x80\x01\n" +
+	"\x02in\x18\x06 \x03(\x0fBp\xc2Hm\n" +
+	"k\n" +
+	"\vsfixed32.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12z\n" +
+	"\x06not_in\x18\a \x03(\x0fBc\xc2H`\n" +
+	"^\n" +
+	"\x0fsfixed32.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x127\n" +
 	"\aexample\x18\b \x03(\x0fB\x1d\xc2H\x1a\n" +
 	"\x18\n" +
 	"\x10sfixed32.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xee\x15\n" +
-	"\rSFixed64Rules\x12\x8d\x01\n" +
-	"\x05const\x18\x01 \x01(\x10Bw\xc2Ht\n" +
-	"r\n" +
-	"\x0esfixed64.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x91\x01\n" +
-	"\x02lt\x18\x02 \x01(\x10B\x7f\xc2H|\n" +
-	"z\n" +
-	"\vsfixed64.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xa4\x01\n" +
-	"\x03lte\x18\x03 \x01(\x10B\x8f\x01\xc2H\x8b\x01\n" +
-	"\x88\x01\n" +
-	"\fsfixed64.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xaa\a\n" +
-	"\x02gt\x18\x04 \x01(\x10B\x97\a\xc2H\x93\a\n" +
-	"}\n" +
-	"\vsfixed64.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb6\x01\n" +
-	"\x0esfixed64.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbe\x01\n" +
-	"\x18sfixed64.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc6\x01\n" +
-	"\x0fsfixed64.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xce\x01\n" +
-	"\x19sfixed64.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xf7\a\n" +
-	"\x03gte\x18\x05 \x01(\x10B\xe2\a\xc2H\xde\a\n" +
-	"\x8b\x01\n" +
-	"\fsfixed64.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc5\x01\n" +
-	"\x0fsfixed64.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xcd\x01\n" +
-	"\x19sfixed64.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd5\x01\n" +
-	"\x10sfixed64.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xdd\x01\n" +
-	"\x1asfixed64.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x86\x01\n" +
-	"\x02in\x18\x06 \x03(\x10Bv\xc2Hs\n" +
-	"q\n" +
-	"\vsfixed64.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\x80\x01\n" +
-	"\x06not_in\x18\a \x03(\x10Bi\xc2Hf\n" +
-	"d\n" +
-	"\x0fsfixed64.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x127\n" +
+	"\fgreater_than\"\x93\x15\n" +
+	"\rSFixed64Rules\x12\x87\x01\n" +
+	"\x05const\x18\x01 \x01(\x10Bq\xc2Hn\n" +
+	"l\n" +
+	"\x0esfixed64.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\x8b\x01\n" +
+	"\x02lt\x18\x02 \x01(\x10By\xc2Hv\n" +
+	"t\n" +
+	"\vsfixed64.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\x9e\x01\n" +
+	"\x03lte\x18\x03 \x01(\x10B\x89\x01\xc2H\x85\x01\n" +
+	"\x82\x01\n" +
+	"\fsfixed64.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\x8c\a\n" +
+	"\x02gt\x18\x04 \x01(\x10B\xf9\x06\xc2H\xf5\x06\n" +
+	"w\n" +
+	"\vsfixed64.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xb0\x01\n" +
+	"\x0esfixed64.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb8\x01\n" +
+	"\x18sfixed64.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xc0\x01\n" +
+	"\x0fsfixed64.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc8\x01\n" +
+	"\x19sfixed64.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xd9\a\n" +
+	"\x03gte\x18\x05 \x01(\x10B\xc4\a\xc2H\xc0\a\n" +
+	"\x85\x01\n" +
+	"\fsfixed64.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbf\x01\n" +
+	"\x0fsfixed64.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc7\x01\n" +
+	"\x19sfixed64.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xcf\x01\n" +
+	"\x10sfixed64.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd7\x01\n" +
+	"\x1asfixed64.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x80\x01\n" +
+	"\x02in\x18\x06 \x03(\x10Bp\xc2Hm\n" +
+	"k\n" +
+	"\vsfixed64.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12z\n" +
+	"\x06not_in\x18\a \x03(\x10Bc\xc2H`\n" +
+	"^\n" +
+	"\x0fsfixed64.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x127\n" +
 	"\aexample\x18\b \x03(\x10B\x1d\xc2H\x1a\n" +
 	"\x18\n" +
 	"\x10sfixed64.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xd7\x01\n" +
-	"\tBoolRules\x12\x89\x01\n" +
-	"\x05const\x18\x01 \x01(\bBs\xc2Hp\n" +
-	"n\n" +
+	"\fgreater_than\"\xd1\x01\n" +
+	"\tBoolRules\x12\x83\x01\n" +
+	"\x05const\x18\x01 \x01(\bBm\xc2Hj\n" +
+	"h\n" +
 	"\n" +
-	"bool.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x123\n" +
+	"bool.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x123\n" +
 	"\aexample\x18\x02 \x03(\bB\x19\xc2H\x16\n" +
 	"\x14\n" +
-	"\fbool.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02\"\xcf;\n" +
-	"\vStringRules\x12\x8d\x01\n" +
-	"\x05const\x18\x01 \x01(\tBw\xc2Ht\n" +
-	"r\n" +
-	"\fstring.const\x1abthis != getField(rules, 'const') ? 'value must equal `%s`'.format([getField(rules, 'const')]) : ''R\x05const\x12\x83\x01\n" +
-	"\x03len\x18\x13 \x01(\x04Bq\xc2Hn\n" +
+	"\fbool.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02\"\xcf?\n" +
+	"\vStringRules\x12\x87\x01\n" +
+	"\x05const\x18\x01 \x01(\tBq\xc2Hn\n" +
 	"l\n" +
+	"\fstring.const\x1a\\this != getField(rules, 'const') ? 'must equal `%s`'.format([getField(rules, 'const')]) : ''R\x05const\x12v\n" +
+	"\x03len\x18\x13 \x01(\x04Bd\xc2Ha\n" +
+	"_\n" +
 	"\n" +
-	"string.len\x1a^uint(this.size()) != rules.len ? 'value length must be %s characters'.format([rules.len]) : ''R\x03len\x12\xa1\x01\n" +
-	"\amin_len\x18\x02 \x01(\x04B\x87\x01\xc2H\x83\x01\n" +
-	"\x80\x01\n" +
-	"\x0estring.min_len\x1anuint(this.size()) < rules.min_len ? 'value length must be at least %s characters'.format([rules.min_len]) : ''R\x06minLen\x12\x9f\x01\n" +
-	"\amax_len\x18\x03 \x01(\x04B\x85\x01\xc2H\x81\x01\n" +
-	"\x7f\n" +
-	"\x0estring.max_len\x1amuint(this.size()) > rules.max_len ? 'value length must be at most %s characters'.format([rules.max_len]) : ''R\x06maxLen\x12\xa5\x01\n" +
-	"\tlen_bytes\x18\x14 \x01(\x04B\x87\x01\xc2H\x83\x01\n" +
-	"\x80\x01\n" +
-	"\x10string.len_bytes\x1aluint(bytes(this).size()) != rules.len_bytes ? 'value length must be %s bytes'.format([rules.len_bytes]) : ''R\blenBytes\x12\xad\x01\n" +
-	"\tmin_bytes\x18\x04 \x01(\x04B\x8f\x01\xc2H\x8b\x01\n" +
-	"\x88\x01\n" +
-	"\x10string.min_bytes\x1atuint(bytes(this).size()) < rules.min_bytes ? 'value length must be at least %s bytes'.format([rules.min_bytes]) : ''R\bminBytes\x12\xac\x01\n" +
-	"\tmax_bytes\x18\x05 \x01(\x04B\x8e\x01\xc2H\x8a\x01\n" +
-	"\x87\x01\n" +
-	"\x10string.max_bytes\x1asuint(bytes(this).size()) > rules.max_bytes ? 'value length must be at most %s bytes'.format([rules.max_bytes]) : ''R\bmaxBytes\x12\x96\x01\n" +
-	"\apattern\x18\x06 \x01(\tB|\xc2Hy\n" +
-	"w\n" +
-	"\x0estring.pattern\x1ae!this.matches(rules.pattern) ? 'value does not match regex pattern `%s`'.format([rules.pattern]) : ''R\apattern\x12\x8c\x01\n" +
-	"\x06prefix\x18\a \x01(\tBt\xc2Hq\n" +
-	"o\n" +
-	"\rstring.prefix\x1a^!this.startsWith(rules.prefix) ? 'value does not have prefix `%s`'.format([rules.prefix]) : ''R\x06prefix\x12\x8a\x01\n" +
-	"\x06suffix\x18\b \x01(\tBr\xc2Ho\n" +
-	"m\n" +
-	"\rstring.suffix\x1a\\!this.endsWith(rules.suffix) ? 'value does not have suffix `%s`'.format([rules.suffix]) : ''R\x06suffix\x12\x9a\x01\n" +
-	"\bcontains\x18\t \x01(\tB~\xc2H{\n" +
-	"y\n" +
-	"\x0fstring.contains\x1af!this.contains(rules.contains) ? 'value does not contain substring `%s`'.format([rules.contains]) : ''R\bcontains\x12\xa5\x01\n" +
-	"\fnot_contains\x18\x17 \x01(\tB\x81\x01\xc2H~\n" +
-	"|\n" +
-	"\x13string.not_contains\x1aethis.contains(rules.not_contains) ? 'value contains substring `%s`'.format([rules.not_contains]) : ''R\vnotContains\x12\x84\x01\n" +
-	"\x02in\x18\n" +
-	" \x03(\tBt\xc2Hq\n" +
-	"o\n" +
-	"\tstring.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12~\n" +
-	"\x06not_in\x18\v \x03(\tBg\xc2Hd\n" +
-	"b\n" +
-	"\rstring.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12\xe6\x01\n" +
-	"\x05email\x18\f \x01(\bB\xcd\x01\xc2H\xc9\x01\n" +
-	"a\n" +
-	"\fstring.email\x12#value must be a valid email address\x1a,!rules.email || this == '' || this.isEmail()\n" +
-	"d\n" +
-	"\x12string.email_empty\x122value is empty, which is not a valid email address\x1a\x1a!rules.email || this != ''H\x00R\x05email\x12\xf1\x01\n" +
-	"\bhostname\x18\r \x01(\bB\xd2\x01\xc2H\xce\x01\n" +
-	"e\n" +
-	"\x0fstring.hostname\x12\x1evalue must be a valid hostname\x1a2!rules.hostname || this == '' || this.isHostname()\n" +
-	"e\n" +
-	"\x15string.hostname_empty\x12-value is empty, which is not a valid hostname\x1a\x1d!rules.hostname || this != ''H\x00R\bhostname\x12\xcb\x01\n" +
-	"\x02ip\x18\x0e \x01(\bB\xb8\x01\xc2H\xb4\x01\n" +
-	"U\n" +
-	"\tstring.ip\x12 value must be a valid IP address\x1a&!rules.ip || this == '' || this.isIp()\n" +
-	"[\n" +
-	"\x0fstring.ip_empty\x12/value is empty, which is not a valid IP address\x1a\x17!rules.ip || this != ''H\x00R\x02ip\x12\xdc\x01\n" +
-	"\x04ipv4\x18\x0f \x01(\bB\xc5\x01\xc2H\xc1\x01\n" +
-	"\\\n" +
-	"\vstring.ipv4\x12\"value must be a valid IPv4 address\x1a)!rules.ipv4 || this == '' || this.isIp(4)\n" +
-	"a\n" +
-	"\x11string.ipv4_empty\x121value is empty, which is not a valid IPv4 address\x1a\x19!rules.ipv4 || this != ''H\x00R\x04ipv4\x12\xdc\x01\n" +
-	"\x04ipv6\x18\x10 \x01(\bB\xc5\x01\xc2H\xc1\x01\n" +
-	"\\\n" +
-	"\vstring.ipv6\x12\"value must be a valid IPv6 address\x1a)!rules.ipv6 || this == '' || this.isIp(6)\n" +
-	"a\n" +
-	"\x11string.ipv6_empty\x121value is empty, which is not a valid IPv6 address\x1a\x19!rules.ipv6 || this != ''H\x00R\x04ipv6\x12\xc4\x01\n" +
-	"\x03uri\x18\x11 \x01(\bB\xaf\x01\xc2H\xab\x01\n" +
-	"Q\n" +
-	"\n" +
-	"string.uri\x12\x19value must be a valid URI\x1a(!rules.uri || this == '' || this.isUri()\n" +
-	"V\n" +
-	"\x10string.uri_empty\x12(value is empty, which is not a valid URI\x1a\x18!rules.uri || this != ''H\x00R\x03uri\x12x\n" +
-	"\auri_ref\x18\x12 \x01(\bB]\xc2HZ\n" +
-	"X\n" +
-	"\x0estring.uri_ref\x12#value must be a valid URI Reference\x1a!!rules.uri_ref || this.isUriRef()H\x00R\x06uriRef\x12\x99\x02\n" +
-	"\aaddress\x18\x15 \x01(\bB\xfc\x01\xc2H\xf8\x01\n" +
-	"\x81\x01\n" +
-	"\x0estring.address\x12-value must be a valid hostname, or ip address\x1a@!rules.address || this == '' || this.isHostname() || this.isIp()\n" +
-	"r\n" +
-	"\x14string.address_empty\x12<value is empty, which is not a valid hostname, or ip address\x1a\x1c!rules.address || this != ''H\x00R\aaddress\x12\x9e\x02\n" +
-	"\x04uuid\x18\x16 \x01(\bB\x87\x02\xc2H\x83\x02\n" +
-	"\xa5\x01\n" +
-	"\vstring.uuid\x12\x1avalue must be a valid UUID\x1az!rules.uuid || this == '' || this.matches('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')\n" +
-	"Y\n" +
-	"\x11string.uuid_empty\x12)value is empty, which is not a valid UUID\x1a\x19!rules.uuid || this != ''H\x00R\x04uuid\x12\xf7\x01\n" +
-	"\x05tuuid\x18! \x01(\bB\xde\x01\xc2H\xda\x01\n" +
+	"string.len\x1aQuint(this.size()) != rules.len ? 'must be %s characters'.format([rules.len]) : ''R\x03len\x12\x91\x01\n" +
+	"\amin_len\x18\x02 \x01(\x04Bx\xc2Hu\n" +
 	"s\n" +
-	"\fstring.tuuid\x12\"value must be a valid trimmed UUID\x1a?!rules.tuuid || this == '' || this.matches('^[0-9a-fA-F]{32}$')\n" +
+	"\x0estring.min_len\x1aauint(this.size()) < rules.min_len ? 'must be at least %s characters'.format([rules.min_len]) : ''R\x06minLen\x12\x90\x01\n" +
+	"\amax_len\x18\x03 \x01(\x04Bw\xc2Ht\n" +
+	"r\n" +
+	"\x0estring.max_len\x1a`uint(this.size()) > rules.max_len ? 'must be at most %s characters'.format([rules.max_len]) : ''R\x06maxLen\x12\x95\x01\n" +
+	"\tlen_bytes\x18\x14 \x01(\x04Bx\xc2Hu\n" +
+	"s\n" +
+	"\x10string.len_bytes\x1a_uint(bytes(this).size()) != rules.len_bytes ? 'must be %s bytes'.format([rules.len_bytes]) : ''R\blenBytes\x12\x9e\x01\n" +
+	"\tmin_bytes\x18\x04 \x01(\x04B\x80\x01\xc2H}\n" +
+	"{\n" +
+	"\x10string.min_bytes\x1aguint(bytes(this).size()) < rules.min_bytes ? 'must be at least %s bytes'.format([rules.min_bytes]) : ''R\bminBytes\x12\x9c\x01\n" +
+	"\tmax_bytes\x18\x05 \x01(\x04B\x7f\xc2H|\n" +
+	"z\n" +
+	"\x10string.max_bytes\x1afuint(bytes(this).size()) > rules.max_bytes ? 'must be at most %s bytes'.format([rules.max_bytes]) : ''R\bmaxBytes\x12\x90\x01\n" +
+	"\apattern\x18\x06 \x01(\tBv\xc2Hs\n" +
+	"q\n" +
+	"\x0estring.pattern\x1a_!this.matches(rules.pattern) ? 'does not match regex pattern `%s`'.format([rules.pattern]) : ''R\apattern\x12\x86\x01\n" +
+	"\x06prefix\x18\a \x01(\tBn\xc2Hk\n" +
+	"i\n" +
+	"\rstring.prefix\x1aX!this.startsWith(rules.prefix) ? 'does not have prefix `%s`'.format([rules.prefix]) : ''R\x06prefix\x12\x84\x01\n" +
+	"\x06suffix\x18\b \x01(\tBl\xc2Hi\n" +
+	"g\n" +
+	"\rstring.suffix\x1aV!this.endsWith(rules.suffix) ? 'does not have suffix `%s`'.format([rules.suffix]) : ''R\x06suffix\x12\x94\x01\n" +
+	"\bcontains\x18\t \x01(\tBx\xc2Hu\n" +
+	"s\n" +
+	"\x0fstring.contains\x1a`!this.contains(rules.contains) ? 'does not contain substring `%s`'.format([rules.contains]) : ''R\bcontains\x12\x9e\x01\n" +
+	"\fnot_contains\x18\x17 \x01(\tB{\xc2Hx\n" +
+	"v\n" +
+	"\x13string.not_contains\x1a_this.contains(rules.not_contains) ? 'contains substring `%s`'.format([rules.not_contains]) : ''R\vnotContains\x12~\n" +
+	"\x02in\x18\n" +
+	" \x03(\tBn\xc2Hk\n" +
+	"i\n" +
+	"\tstring.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12x\n" +
+	"\x06not_in\x18\v \x03(\tBa\xc2H^\n" +
+	"\\\n" +
+	"\rstring.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12\xe0\x01\n" +
+	"\x05email\x18\f \x01(\bB\xc7\x01\xc2H\xc3\x01\n" +
+	"[\n" +
+	"\fstring.email\x12\x1dmust be a valid email address\x1a,!rules.email || this == '' || this.isEmail()\n" +
+	"d\n" +
+	"\x12string.email_empty\x122value is empty, which is not a valid email address\x1a\x1a!rules.email || this != ''H\x00R\x05email\x12\xeb\x01\n" +
+	"\bhostname\x18\r \x01(\bB\xcc\x01\xc2H\xc8\x01\n" +
+	"_\n" +
+	"\x0fstring.hostname\x12\x18must be a valid hostname\x1a2!rules.hostname || this == '' || this.isHostname()\n" +
+	"e\n" +
+	"\x15string.hostname_empty\x12-value is empty, which is not a valid hostname\x1a\x1d!rules.hostname || this != ''H\x00R\bhostname\x12\xc5\x01\n" +
+	"\x02ip\x18\x0e \x01(\bB\xb2\x01\xc2H\xae\x01\n" +
+	"O\n" +
+	"\tstring.ip\x12\x1amust be a valid IP address\x1a&!rules.ip || this == '' || this.isIp()\n" +
+	"[\n" +
+	"\x0fstring.ip_empty\x12/value is empty, which is not a valid IP address\x1a\x17!rules.ip || this != ''H\x00R\x02ip\x12\xd6\x01\n" +
+	"\x04ipv4\x18\x0f \x01(\bB\xbf\x01\xc2H\xbb\x01\n" +
+	"V\n" +
+	"\vstring.ipv4\x12\x1cmust be a valid IPv4 address\x1a)!rules.ipv4 || this == '' || this.isIp(4)\n" +
+	"a\n" +
+	"\x11string.ipv4_empty\x121value is empty, which is not a valid IPv4 address\x1a\x19!rules.ipv4 || this != ''H\x00R\x04ipv4\x12\xd6\x01\n" +
+	"\x04ipv6\x18\x10 \x01(\bB\xbf\x01\xc2H\xbb\x01\n" +
+	"V\n" +
+	"\vstring.ipv6\x12\x1cmust be a valid IPv6 address\x1a)!rules.ipv6 || this == '' || this.isIp(6)\n" +
+	"a\n" +
+	"\x11string.ipv6_empty\x121value is empty, which is not a valid IPv6 address\x1a\x19!rules.ipv6 || this != ''H\x00R\x04ipv6\x12\xbe\x01\n" +
+	"\x03uri\x18\x11 \x01(\bB\xa9\x01\xc2H\xa5\x01\n" +
+	"K\n" +
+	"\n" +
+	"string.uri\x12\x13must be a valid URI\x1a(!rules.uri || this == '' || this.isUri()\n" +
+	"V\n" +
+	"\x10string.uri_empty\x12(value is empty, which is not a valid URI\x1a\x18!rules.uri || this != ''H\x00R\x03uri\x12r\n" +
+	"\auri_ref\x18\x12 \x01(\bBW\xc2HT\n" +
+	"R\n" +
+	"\x0estring.uri_ref\x12\x1dmust be a valid URI Reference\x1a!!rules.uri_ref || this.isUriRef()H\x00R\x06uriRef\x12\x92\x02\n" +
+	"\aaddress\x18\x15 \x01(\bB\xf5\x01\xc2H\xf1\x01\n" +
+	"{\n" +
+	"\x0estring.address\x12'must be a valid hostname, or ip address\x1a@!rules.address || this == '' || this.isHostname() || this.isIp()\n" +
+	"r\n" +
+	"\x14string.address_empty\x12<value is empty, which is not a valid hostname, or ip address\x1a\x1c!rules.address || this != ''H\x00R\aaddress\x12\x98\x02\n" +
+	"\x04uuid\x18\x16 \x01(\bB\x81\x02\xc2H\xfd\x01\n" +
+	"\x9f\x01\n" +
+	"\vstring.uuid\x12\x14must be a valid UUID\x1az!rules.uuid || this == '' || this.matches('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')\n" +
+	"Y\n" +
+	"\x11string.uuid_empty\x12)value is empty, which is not a valid UUID\x1a\x19!rules.uuid || this != ''H\x00R\x04uuid\x12\xf1\x01\n" +
+	"\x05tuuid\x18! \x01(\bB\xd8\x01\xc2H\xd4\x01\n" +
+	"m\n" +
+	"\fstring.tuuid\x12\x1cmust be a valid trimmed UUID\x1a?!rules.tuuid || this == '' || this.matches('^[0-9a-fA-F]{32}$')\n" +
 	"c\n" +
-	"\x12string.tuuid_empty\x121value is empty, which is not a valid trimmed UUID\x1a\x1a!rules.tuuid || this != ''H\x00R\x05tuuid\x12\xa7\x02\n" +
-	"\x11ip_with_prefixlen\x18\x1a \x01(\bB\xf8\x01\xc2H\xf4\x01\n" +
+	"\x12string.tuuid_empty\x121value is empty, which is not a valid trimmed UUID\x1a\x1a!rules.tuuid || this != ''H\x00R\x05tuuid\x12\xa1\x02\n" +
+	"\x11ip_with_prefixlen\x18\x1a \x01(\bB\xf2\x01\xc2H\xee\x01\n" +
+	"r\n" +
+	"\x18string.ip_with_prefixlen\x12\x19must be a valid IP prefix\x1a;!rules.ip_with_prefixlen || this == '' || this.isIpPrefix()\n" +
 	"x\n" +
-	"\x18string.ip_with_prefixlen\x12\x1fvalue must be a valid IP prefix\x1a;!rules.ip_with_prefixlen || this == '' || this.isIpPrefix()\n" +
-	"x\n" +
-	"\x1estring.ip_with_prefixlen_empty\x12.value is empty, which is not a valid IP prefix\x1a&!rules.ip_with_prefixlen || this != ''H\x00R\x0fipWithPrefixlen\x12\xe2\x02\n" +
-	"\x13ipv4_with_prefixlen\x18\x1b \x01(\bB\xaf\x02\xc2H\xab\x02\n" +
-	"\x93\x01\n" +
-	"\x1astring.ipv4_with_prefixlen\x125value must be a valid IPv4 address with prefix length\x1a>!rules.ipv4_with_prefixlen || this == '' || this.isIpPrefix(4)\n" +
+	"\x1estring.ip_with_prefixlen_empty\x12.value is empty, which is not a valid IP prefix\x1a&!rules.ip_with_prefixlen || this != ''H\x00R\x0fipWithPrefixlen\x12\xdc\x02\n" +
+	"\x13ipv4_with_prefixlen\x18\x1b \x01(\bB\xa9\x02\xc2H\xa5\x02\n" +
+	"\x8d\x01\n" +
+	"\x1astring.ipv4_with_prefixlen\x12/must be a valid IPv4 address with prefix length\x1a>!rules.ipv4_with_prefixlen || this == '' || this.isIpPrefix(4)\n" +
 	"\x92\x01\n" +
-	" string.ipv4_with_prefixlen_empty\x12Dvalue is empty, which is not a valid IPv4 address with prefix length\x1a(!rules.ipv4_with_prefixlen || this != ''H\x00R\x11ipv4WithPrefixlen\x12\xe2\x02\n" +
-	"\x13ipv6_with_prefixlen\x18\x1c \x01(\bB\xaf\x02\xc2H\xab\x02\n" +
-	"\x93\x01\n" +
-	"\x1astring.ipv6_with_prefixlen\x125value must be a valid IPv6 address with prefix length\x1a>!rules.ipv6_with_prefixlen || this == '' || this.isIpPrefix(6)\n" +
+	" string.ipv4_with_prefixlen_empty\x12Dvalue is empty, which is not a valid IPv4 address with prefix length\x1a(!rules.ipv4_with_prefixlen || this != ''H\x00R\x11ipv4WithPrefixlen\x12\xdc\x02\n" +
+	"\x13ipv6_with_prefixlen\x18\x1c \x01(\bB\xa9\x02\xc2H\xa5\x02\n" +
+	"\x8d\x01\n" +
+	"\x1astring.ipv6_with_prefixlen\x12/must be a valid IPv6 address with prefix length\x1a>!rules.ipv6_with_prefixlen || this == '' || this.isIpPrefix(6)\n" +
 	"\x92\x01\n" +
-	" string.ipv6_with_prefixlen_empty\x12Dvalue is empty, which is not a valid IPv6 address with prefix length\x1a(!rules.ipv6_with_prefixlen || this != ''H\x00R\x11ipv6WithPrefixlen\x12\xfc\x01\n" +
-	"\tip_prefix\x18\x1d \x01(\bB\xdc\x01\xc2H\xd8\x01\n" +
-	"l\n" +
-	"\x10string.ip_prefix\x12\x1fvalue must be a valid IP prefix\x1a7!rules.ip_prefix || this == '' || this.isIpPrefix(true)\n" +
+	" string.ipv6_with_prefixlen_empty\x12Dvalue is empty, which is not a valid IPv6 address with prefix length\x1a(!rules.ipv6_with_prefixlen || this != ''H\x00R\x11ipv6WithPrefixlen\x12\xf6\x01\n" +
+	"\tip_prefix\x18\x1d \x01(\bB\xd6\x01\xc2H\xd2\x01\n" +
+	"f\n" +
+	"\x10string.ip_prefix\x12\x19must be a valid IP prefix\x1a7!rules.ip_prefix || this == '' || this.isIpPrefix(true)\n" +
 	"h\n" +
-	"\x16string.ip_prefix_empty\x12.value is empty, which is not a valid IP prefix\x1a\x1e!rules.ip_prefix || this != ''H\x00R\bipPrefix\x12\x8f\x02\n" +
-	"\vipv4_prefix\x18\x1e \x01(\bB\xeb\x01\xc2H\xe7\x01\n" +
-	"u\n" +
-	"\x12string.ipv4_prefix\x12!value must be a valid IPv4 prefix\x1a<!rules.ipv4_prefix || this == '' || this.isIpPrefix(4, true)\n" +
+	"\x16string.ip_prefix_empty\x12.value is empty, which is not a valid IP prefix\x1a\x1e!rules.ip_prefix || this != ''H\x00R\bipPrefix\x12\x89\x02\n" +
+	"\vipv4_prefix\x18\x1e \x01(\bB\xe5\x01\xc2H\xe1\x01\n" +
+	"o\n" +
+	"\x12string.ipv4_prefix\x12\x1bmust be a valid IPv4 prefix\x1a<!rules.ipv4_prefix || this == '' || this.isIpPrefix(4, true)\n" +
 	"n\n" +
 	"\x18string.ipv4_prefix_empty\x120value is empty, which is not a valid IPv4 prefix\x1a !rules.ipv4_prefix || this != ''H\x00R\n" +
-	"ipv4Prefix\x12\x8f\x02\n" +
-	"\vipv6_prefix\x18\x1f \x01(\bB\xeb\x01\xc2H\xe7\x01\n" +
-	"u\n" +
-	"\x12string.ipv6_prefix\x12!value must be a valid IPv6 prefix\x1a<!rules.ipv6_prefix || this == '' || this.isIpPrefix(6, true)\n" +
+	"ipv4Prefix\x12\x89\x02\n" +
+	"\vipv6_prefix\x18\x1f \x01(\bB\xe5\x01\xc2H\xe1\x01\n" +
+	"o\n" +
+	"\x12string.ipv6_prefix\x12\x1bmust be a valid IPv6 prefix\x1a<!rules.ipv6_prefix || this == '' || this.isIpPrefix(6, true)\n" +
 	"n\n" +
 	"\x18string.ipv6_prefix_empty\x120value is empty, which is not a valid IPv6 prefix\x1a !rules.ipv6_prefix || this != ''H\x00R\n" +
-	"ipv6Prefix\x12\xc2\x02\n" +
-	"\rhost_and_port\x18  \x01(\bB\x9b\x02\xc2H\x97\x02\n" +
-	"\x99\x01\n" +
-	"\x14string.host_and_port\x12Avalue must be a valid host (hostname or IP address) and port pair\x1a>!rules.host_and_port || this == '' || this.isHostAndPort(true)\n" +
+	"ipv6Prefix\x12\xbc\x02\n" +
+	"\rhost_and_port\x18  \x01(\bB\x95\x02\xc2H\x91\x02\n" +
+	"\x93\x01\n" +
+	"\x14string.host_and_port\x12;must be a valid host (hostname or IP address) and port pair\x1a>!rules.host_and_port || this == '' || this.isHostAndPort(true)\n" +
 	"y\n" +
-	"\x1astring.host_and_port_empty\x127value is empty, which is not a valid host and port pair\x1a\"!rules.host_and_port || this != ''H\x00R\vhostAndPort\x12\xfb\x01\n" +
-	"\x04ulid\x18# \x01(\bB\xe4\x01\xc2H\xe0\x01\n" +
-	"\x82\x01\n" +
-	"\vstring.ulid\x12\x1avalue must be a valid ULID\x1aW!rules.ulid || this == '' || this.matches('^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$')\n" +
+	"\x1astring.host_and_port_empty\x127value is empty, which is not a valid host and port pair\x1a\"!rules.host_and_port || this != ''H\x00R\vhostAndPort\x12\xf4\x01\n" +
+	"\x04ulid\x18# \x01(\bB\xdd\x01\xc2H\xd9\x01\n" +
+	"|\n" +
+	"\vstring.ulid\x12\x14must be a valid ULID\x1aW!rules.ulid || this == '' || this.matches('^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$')\n" +
 	"Y\n" +
-	"\x11string.ulid_empty\x12)value is empty, which is not a valid ULID\x1a\x19!rules.ulid || this != ''H\x00R\x04ulid\x12\xb8\x05\n" +
-	"\x10well_known_regex\x18\x18 \x01(\x0e2\x18.buf.validate.KnownRegexB\xf1\x04\xc2H\xed\x04\n" +
-	"\xf0\x01\n" +
-	"#string.well_known_regex.header_name\x12&value must be a valid HTTP header name\x1a\xa0\x01rules.well_known_regex != 1 || this == '' || this.matches(!has(rules.strict) || rules.strict ?'^:?[0-9a-zA-Z!#$%&\\'*+-.^_|~\\x60]+$' :'^[^\\u0000\\u000A\\u000D]+$')\n" +
+	"\x11string.ulid_empty\x12)value is empty, which is not a valid ULID\x1a\x19!rules.ulid || this != ''H\x00R\x04ulid\x12\xe1\x02\n" +
+	"\fprotobuf_fqn\x18% \x01(\bB\xbb\x02\xc2H\xb7\x02\n" +
+	"\xaf\x01\n" +
+	"\x13string.protobuf_fqn\x12-must be a valid fully-qualified Protobuf name\x1ai!rules.protobuf_fqn || this == '' || this.matches('^[A-Za-z_][A-Za-z_0-9]*(\\\\.[A-Za-z_][A-Za-z_0-9]*)*$')\n" +
+	"\x82\x01\n" +
+	"\x19string.protobuf_fqn_empty\x12Bvalue is empty, which is not a valid fully-qualified Protobuf name\x1a!!rules.protobuf_fqn || this != ''H\x00R\vprotobufFqn\x12\xa1\x03\n" +
+	"\x10protobuf_dot_fqn\x18& \x01(\bB\xf4\x02\xc2H\xf0\x02\n" +
+	"\xcd\x01\n" +
+	"\x17string.protobuf_dot_fqn\x12@must be a valid fully-qualified Protobuf name with a leading dot\x1ap!rules.protobuf_dot_fqn || this == '' || this.matches('^\\\\.[A-Za-z_][A-Za-z_0-9]*(\\\\.[A-Za-z_][A-Za-z_0-9]*)*$')\n" +
+	"\x9d\x01\n" +
+	"\x1dstring.protobuf_dot_fqn_empty\x12Uvalue is empty, which is not a valid fully-qualified Protobuf name with a leading dot\x1a%!rules.protobuf_dot_fqn || this != ''H\x00R\x0eprotobufDotFqn\x12\xac\x05\n" +
+	"\x10well_known_regex\x18\x18 \x01(\x0e2\x18.buf.validate.KnownRegexB\xe5\x04\xc2H\xe1\x04\n" +
+	"\xea\x01\n" +
+	"#string.well_known_regex.header_name\x12 must be a valid HTTP header name\x1a\xa0\x01rules.well_known_regex != 1 || this == '' || this.matches(!has(rules.strict) || rules.strict ?'^:?[0-9a-zA-Z!#$%&\\'*+-.^_|~\\x60]+$' :'^[^\\u0000\\u000A\\u000D]+$')\n" +
 	"\x8d\x01\n" +
 	")string.well_known_regex.header_name_empty\x125value is empty, which is not a valid HTTP header name\x1a)rules.well_known_regex != 1 || this != ''\n" +
-	"\xe7\x01\n" +
-	"$string.well_known_regex.header_value\x12'value must be a valid HTTP header value\x1a\x95\x01rules.well_known_regex != 2 || this.matches(!has(rules.strict) || rules.strict ?'^[^\\u0000-\\u0008\\u000A-\\u001F\\u007F]*$' :'^[^\\u0000\\u000A\\u000D]*$')H\x00R\x0ewellKnownRegex\x12\x16\n" +
+	"\xe1\x01\n" +
+	"$string.well_known_regex.header_value\x12!must be a valid HTTP header value\x1a\x95\x01rules.well_known_regex != 2 || this.matches(!has(rules.strict) || rules.strict ?'^[^\\u0000-\\u0008\\u000A-\\u001F\\u007F]*$' :'^[^\\u0000\\u000A\\u000D]*$')H\x00R\x0ewellKnownRegex\x12\x16\n" +
 	"\x06strict\x18\x19 \x01(\bR\x06strict\x125\n" +
 	"\aexample\x18\" \x03(\tB\x1b\xc2H\x18\n" +
 	"\x16\n" +
 	"\x0estring.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\f\n" +
 	"\n" +
-	"well_known\"\xac\x13\n" +
+	"well_known\"\xca\x12\n" +
 	"\n" +
-	"BytesRules\x12\x87\x01\n" +
-	"\x05const\x18\x01 \x01(\fBq\xc2Hn\n" +
-	"l\n" +
-	"\vbytes.const\x1a]this != getField(rules, 'const') ? 'value must be %x'.format([getField(rules, 'const')]) : ''R\x05const\x12}\n" +
-	"\x03len\x18\r \x01(\x04Bk\xc2Hh\n" +
+	"BytesRules\x12\x81\x01\n" +
+	"\x05const\x18\x01 \x01(\fBk\xc2Hh\n" +
 	"f\n" +
-	"\tbytes.len\x1aYuint(this.size()) != rules.len ? 'value length must be %s bytes'.format([rules.len]) : ''R\x03len\x12\x98\x01\n" +
-	"\amin_len\x18\x02 \x01(\x04B\x7f\xc2H|\n" +
-	"z\n" +
-	"\rbytes.min_len\x1aiuint(this.size()) < rules.min_len ? 'value length must be at least %s bytes'.format([rules.min_len]) : ''R\x06minLen\x12\x90\x01\n" +
-	"\amax_len\x18\x03 \x01(\x04Bw\xc2Ht\n" +
-	"r\n" +
-	"\rbytes.max_len\x1aauint(this.size()) > rules.max_len ? 'value must be at most %s bytes'.format([rules.max_len]) : ''R\x06maxLen\x12\x99\x01\n" +
-	"\apattern\x18\x04 \x01(\tB\x7f\xc2H|\n" +
-	"z\n" +
-	"\rbytes.pattern\x1ai!string(this).matches(rules.pattern) ? 'value must match regex pattern `%s`'.format([rules.pattern]) : ''R\apattern\x12\x89\x01\n" +
-	"\x06prefix\x18\x05 \x01(\fBq\xc2Hn\n" +
+	"\vbytes.const\x1aWthis != getField(rules, 'const') ? 'must be %x'.format([getField(rules, 'const')]) : ''R\x05const\x12p\n" +
+	"\x03len\x18\r \x01(\x04B^\xc2H[\n" +
+	"Y\n" +
+	"\tbytes.len\x1aLuint(this.size()) != rules.len ? 'must be %s bytes'.format([rules.len]) : ''R\x03len\x12\x8b\x01\n" +
+	"\amin_len\x18\x02 \x01(\x04Br\xc2Ho\n" +
+	"m\n" +
+	"\rbytes.min_len\x1a\\uint(this.size()) < rules.min_len ? 'must be at least %s bytes'.format([rules.min_len]) : ''R\x06minLen\x12\x8a\x01\n" +
+	"\amax_len\x18\x03 \x01(\x04Bq\xc2Hn\n" +
 	"l\n" +
-	"\fbytes.prefix\x1a\\!this.startsWith(rules.prefix) ? 'value does not have prefix %x'.format([rules.prefix]) : ''R\x06prefix\x12\x87\x01\n" +
-	"\x06suffix\x18\x06 \x01(\fBo\xc2Hl\n" +
-	"j\n" +
-	"\fbytes.suffix\x1aZ!this.endsWith(rules.suffix) ? 'value does not have suffix %x'.format([rules.suffix]) : ''R\x06suffix\x12\x8d\x01\n" +
-	"\bcontains\x18\a \x01(\fBq\xc2Hn\n" +
-	"l\n" +
-	"\x0ebytes.contains\x1aZ!this.contains(rules.contains) ? 'value does not contain %x'.format([rules.contains]) : ''R\bcontains\x12\xab\x01\n" +
-	"\x02in\x18\b \x03(\fB\x9a\x01\xc2H\x96\x01\n" +
-	"\x93\x01\n" +
-	"\bbytes.in\x1a\x86\x01getField(rules, 'in').size() > 0 && !(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12}\n" +
-	"\x06not_in\x18\t \x03(\fBf\xc2Hc\n" +
-	"a\n" +
-	"\fbytes.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12\xef\x01\n" +
-	"\x02ip\x18\n" +
-	" \x01(\bB\xdc\x01\xc2H\xd8\x01\n" +
+	"\rbytes.max_len\x1a[uint(this.size()) > rules.max_len ? 'must be at most %s bytes'.format([rules.max_len]) : ''R\x06maxLen\x12\x93\x01\n" +
+	"\apattern\x18\x04 \x01(\tBy\xc2Hv\n" +
 	"t\n" +
-	"\bbytes.ip\x12 value must be a valid IP address\x1aF!rules.ip || this.size() == 0 || this.size() == 4 || this.size() == 16\n" +
+	"\rbytes.pattern\x1ac!string(this).matches(rules.pattern) ? 'must match regex pattern `%s`'.format([rules.pattern]) : ''R\apattern\x12\x83\x01\n" +
+	"\x06prefix\x18\x05 \x01(\fBk\xc2Hh\n" +
+	"f\n" +
+	"\fbytes.prefix\x1aV!this.startsWith(rules.prefix) ? 'does not have prefix %x'.format([rules.prefix]) : ''R\x06prefix\x12\x81\x01\n" +
+	"\x06suffix\x18\x06 \x01(\fBi\xc2Hf\n" +
+	"d\n" +
+	"\fbytes.suffix\x1aT!this.endsWith(rules.suffix) ? 'does not have suffix %x'.format([rules.suffix]) : ''R\x06suffix\x12\x87\x01\n" +
+	"\bcontains\x18\a \x01(\fBk\xc2Hh\n" +
+	"f\n" +
+	"\x0ebytes.contains\x1aT!this.contains(rules.contains) ? 'does not contain %x'.format([rules.contains]) : ''R\bcontains\x12\xa5\x01\n" +
+	"\x02in\x18\b \x03(\fB\x94\x01\xc2H\x90\x01\n" +
+	"\x8d\x01\n" +
+	"\bbytes.in\x1a\x80\x01getField(rules, 'in').size() > 0 && !(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12w\n" +
+	"\x06not_in\x18\t \x03(\fB`\xc2H]\n" +
+	"[\n" +
+	"\fbytes.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12\xe9\x01\n" +
+	"\x02ip\x18\n" +
+	" \x01(\bB\xd6\x01\xc2H\xd2\x01\n" +
+	"n\n" +
+	"\bbytes.ip\x12\x1amust be a valid IP address\x1aF!rules.ip || this.size() == 0 || this.size() == 4 || this.size() == 16\n" +
 	"`\n" +
-	"\x0ebytes.ip_empty\x12/value is empty, which is not a valid IP address\x1a\x1d!rules.ip || this.size() != 0H\x00R\x02ip\x12\xea\x01\n" +
-	"\x04ipv4\x18\v \x01(\bB\xd3\x01\xc2H\xcf\x01\n" +
-	"e\n" +
+	"\x0ebytes.ip_empty\x12/value is empty, which is not a valid IP address\x1a\x1d!rules.ip || this.size() != 0H\x00R\x02ip\x12\xe4\x01\n" +
+	"\x04ipv4\x18\v \x01(\bB\xcd\x01\xc2H\xc9\x01\n" +
+	"_\n" +
 	"\n" +
-	"bytes.ipv4\x12\"value must be a valid IPv4 address\x1a3!rules.ipv4 || this.size() == 0 || this.size() == 4\n" +
+	"bytes.ipv4\x12\x1cmust be a valid IPv4 address\x1a3!rules.ipv4 || this.size() == 0 || this.size() == 4\n" +
 	"f\n" +
-	"\x10bytes.ipv4_empty\x121value is empty, which is not a valid IPv4 address\x1a\x1f!rules.ipv4 || this.size() != 0H\x00R\x04ipv4\x12\xeb\x01\n" +
-	"\x04ipv6\x18\f \x01(\bB\xd4\x01\xc2H\xd0\x01\n" +
-	"f\n" +
+	"\x10bytes.ipv4_empty\x121value is empty, which is not a valid IPv4 address\x1a\x1f!rules.ipv4 || this.size() != 0H\x00R\x04ipv4\x12\xe5\x01\n" +
+	"\x04ipv6\x18\f \x01(\bB\xce\x01\xc2H\xca\x01\n" +
+	"`\n" +
 	"\n" +
-	"bytes.ipv6\x12\"value must be a valid IPv6 address\x1a4!rules.ipv6 || this.size() == 0 || this.size() == 16\n" +
+	"bytes.ipv6\x12\x1cmust be a valid IPv6 address\x1a4!rules.ipv6 || this.size() == 0 || this.size() == 16\n" +
 	"f\n" +
-	"\x10bytes.ipv6_empty\x121value is empty, which is not a valid IPv6 address\x1a\x1f!rules.ipv6 || this.size() != 0H\x00R\x04ipv6\x12\xdb\x01\n" +
-	"\x04uuid\x18\x0f \x01(\bB\xc4\x01\xc2H\xc0\x01\n" +
-	"^\n" +
+	"\x10bytes.ipv6_empty\x121value is empty, which is not a valid IPv6 address\x1a\x1f!rules.ipv6 || this.size() != 0H\x00R\x04ipv6\x12\xd5\x01\n" +
+	"\x04uuid\x18\x0f \x01(\bB\xbe\x01\xc2H\xba\x01\n" +
+	"X\n" +
 	"\n" +
-	"bytes.uuid\x12\x1avalue must be a valid UUID\x1a4!rules.uuid || this.size() == 0 || this.size() == 16\n" +
+	"bytes.uuid\x12\x14must be a valid UUID\x1a4!rules.uuid || this.size() == 0 || this.size() == 16\n" +
 	"^\n" +
 	"\x10bytes.uuid_empty\x12)value is empty, which is not a valid UUID\x1a\x1f!rules.uuid || this.size() != 0H\x00R\x04uuid\x124\n" +
 	"\aexample\x18\x0e \x03(\fB\x1a\xc2H\x17\n" +
 	"\x15\n" +
 	"\rbytes.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\f\n" +
 	"\n" +
-	"well_known\"\xfd\x03\n" +
-	"\tEnumRules\x12\x89\x01\n" +
-	"\x05const\x18\x01 \x01(\x05Bs\xc2Hp\n" +
-	"n\n" +
+	"well_known\"\xea\x03\n" +
+	"\tEnumRules\x12\x83\x01\n" +
+	"\x05const\x18\x01 \x01(\x05Bm\xc2Hj\n" +
+	"h\n" +
 	"\n" +
-	"enum.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12!\n" +
-	"\fdefined_only\x18\x02 \x01(\bR\vdefinedOnly\x12\x82\x01\n" +
-	"\x02in\x18\x03 \x03(\x05Br\xc2Ho\n" +
-	"m\n" +
-	"\aenum.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12|\n" +
-	"\x06not_in\x18\x04 \x03(\x05Be\xc2Hb\n" +
-	"`\n" +
-	"\venum.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x123\n" +
+	"enum.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12!\n" +
+	"\fdefined_only\x18\x02 \x01(\bR\vdefinedOnly\x12|\n" +
+	"\x02in\x18\x03 \x03(\x05Bl\xc2Hi\n" +
+	"g\n" +
+	"\aenum.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12v\n" +
+	"\x06not_in\x18\x04 \x03(\x05B_\xc2H\\\n" +
+	"Z\n" +
+	"\venum.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x123\n" +
 	"\aexample\x18\x05 \x03(\x05B\x19\xc2H\x16\n" +
 	"\x14\n" +
-	"\fenum.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02\"\x9e\x04\n" +
-	"\rRepeatedRules\x12\xa8\x01\n" +
-	"\tmin_items\x18\x01 \x01(\x04B\x8a\x01\xc2H\x86\x01\n" +
-	"\x83\x01\n" +
-	"\x12repeated.min_items\x1amuint(this.size()) < rules.min_items ? 'value must contain at least %d item(s)'.format([rules.min_items]) : ''R\bminItems\x12\xac\x01\n" +
-	"\tmax_items\x18\x02 \x01(\x04B\x8e\x01\xc2H\x8a\x01\n" +
-	"\x87\x01\n" +
-	"\x12repeated.max_items\x1aquint(this.size()) > rules.max_items ? 'value must contain no more than %s item(s)'.format([rules.max_items]) : ''R\bmaxItems\x12x\n" +
+	"\fenum.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02\"\x90\x04\n" +
+	"\rRepeatedRules\x12\xa0\x01\n" +
+	"\tmin_items\x18\x01 \x01(\x04B\x82\x01\xc2H\x7f\n" +
+	"}\n" +
+	"\x12repeated.min_items\x1aguint(this.size()) < rules.min_items ? 'must contain at least %d item(s)'.format([rules.min_items]) : ''R\bminItems\x12\xa6\x01\n" +
+	"\tmax_items\x18\x02 \x01(\x04B\x88\x01\xc2H\x84\x01\n" +
+	"\x81\x01\n" +
+	"\x12repeated.max_items\x1akuint(this.size()) > rules.max_items ? 'must contain no more than %s item(s)'.format([rules.max_items]) : ''R\bmaxItems\x12x\n" +
 	"\x06unique\x18\x03 \x01(\bB`\xc2H]\n" +
 	"[\n" +
 	"\x0frepeated.unique\x12(repeated value must contain unique items\x1a\x1e!rules.unique || this.unique()R\x06unique\x12.\n" +
@@ -8619,104 +8712,104 @@ const file_buf_validate_validate_proto_rawDesc = "" +
 	"\x06values\x18\x05 \x01(\v2\x18.buf.validate.FieldRulesR\x06values*\t\b\xe8\a\x10\x80\x80\x80\x80\x02\"1\n" +
 	"\bAnyRules\x12\x0e\n" +
 	"\x02in\x18\x02 \x03(\tR\x02in\x12\x15\n" +
-	"\x06not_in\x18\x03 \x03(\tR\x05notIn\"\xc6\x17\n" +
-	"\rDurationRules\x12\xa8\x01\n" +
-	"\x05const\x18\x02 \x01(\v2\x19.google.protobuf.DurationBw\xc2Ht\n" +
-	"r\n" +
-	"\x0eduration.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\xac\x01\n" +
-	"\x02lt\x18\x03 \x01(\v2\x19.google.protobuf.DurationB\x7f\xc2H|\n" +
-	"z\n" +
-	"\vduration.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xbf\x01\n" +
-	"\x03lte\x18\x04 \x01(\v2\x19.google.protobuf.DurationB\x8f\x01\xc2H\x8b\x01\n" +
-	"\x88\x01\n" +
-	"\fduration.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xc5\a\n" +
-	"\x02gt\x18\x05 \x01(\v2\x19.google.protobuf.DurationB\x97\a\xc2H\x93\a\n" +
-	"}\n" +
-	"\vduration.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb6\x01\n" +
-	"\x0eduration.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbe\x01\n" +
-	"\x18duration.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc6\x01\n" +
-	"\x0fduration.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xce\x01\n" +
-	"\x19duration.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\x92\b\n" +
-	"\x03gte\x18\x06 \x01(\v2\x19.google.protobuf.DurationB\xe2\a\xc2H\xde\a\n" +
-	"\x8b\x01\n" +
-	"\fduration.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc5\x01\n" +
-	"\x0fduration.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xcd\x01\n" +
-	"\x19duration.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd5\x01\n" +
-	"\x10duration.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xdd\x01\n" +
-	"\x1aduration.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\xa1\x01\n" +
-	"\x02in\x18\a \x03(\v2\x19.google.protobuf.DurationBv\xc2Hs\n" +
-	"q\n" +
-	"\vduration.in\x1ab!(this in getField(rules, 'in')) ? 'value must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\x9b\x01\n" +
-	"\x06not_in\x18\b \x03(\v2\x19.google.protobuf.DurationBi\xc2Hf\n" +
-	"d\n" +
-	"\x0fduration.not_in\x1aQthis in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12R\n" +
+	"\x06not_in\x18\x03 \x03(\tR\x05notIn\"\xec\x16\n" +
+	"\rDurationRules\x12\xa2\x01\n" +
+	"\x05const\x18\x02 \x01(\v2\x19.google.protobuf.DurationBq\xc2Hn\n" +
+	"l\n" +
+	"\x0eduration.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\xa6\x01\n" +
+	"\x02lt\x18\x03 \x01(\v2\x19.google.protobuf.DurationBy\xc2Hv\n" +
+	"t\n" +
+	"\vduration.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xb9\x01\n" +
+	"\x03lte\x18\x04 \x01(\v2\x19.google.protobuf.DurationB\x89\x01\xc2H\x85\x01\n" +
+	"\x82\x01\n" +
+	"\fduration.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12\xa7\a\n" +
+	"\x02gt\x18\x05 \x01(\v2\x19.google.protobuf.DurationB\xf9\x06\xc2H\xf5\x06\n" +
+	"w\n" +
+	"\vduration.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xb0\x01\n" +
+	"\x0eduration.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb8\x01\n" +
+	"\x18duration.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xc0\x01\n" +
+	"\x0fduration.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc8\x01\n" +
+	"\x19duration.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xf4\a\n" +
+	"\x03gte\x18\x06 \x01(\v2\x19.google.protobuf.DurationB\xc4\a\xc2H\xc0\a\n" +
+	"\x85\x01\n" +
+	"\fduration.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xbf\x01\n" +
+	"\x0fduration.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc7\x01\n" +
+	"\x19duration.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xcf\x01\n" +
+	"\x10duration.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd7\x01\n" +
+	"\x1aduration.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12\x9b\x01\n" +
+	"\x02in\x18\a \x03(\v2\x19.google.protobuf.DurationBp\xc2Hm\n" +
+	"k\n" +
+	"\vduration.in\x1a\\!(this in getField(rules, 'in')) ? 'must be in list %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\x95\x01\n" +
+	"\x06not_in\x18\b \x03(\v2\x19.google.protobuf.DurationBc\xc2H`\n" +
+	"^\n" +
+	"\x0fduration.not_in\x1aKthis in rules.not_in ? 'must not be in list %s'.format([rules.not_in]) : ''R\x05notIn\x12R\n" +
 	"\aexample\x18\t \x03(\v2\x19.google.protobuf.DurationB\x1d\xc2H\x1a\n" +
 	"\x18\n" +
 	"\x10duration.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\x98\x06\n" +
-	"\x0eFieldMaskRules\x12\xc6\x01\n" +
-	"\x05const\x18\x01 \x01(\v2\x1a.google.protobuf.FieldMaskB\x93\x01\xc2H\x8f\x01\n" +
-	"\x8c\x01\n" +
-	"\x10field_mask.const\x1axthis.paths != getField(rules, 'const').paths ? 'value must equal paths %s'.format([getField(rules, 'const').paths]) : ''R\x05const\x12\xdd\x01\n" +
-	"\x02in\x18\x02 \x03(\tB\xcc\x01\xc2H\xc8\x01\n" +
-	"\xc5\x01\n" +
-	"\rfield_mask.in\x1a\xb3\x01!this.paths.all(p, p in getField(rules, 'in') || getField(rules, 'in').exists(f, p.startsWith(f+'.'))) ? 'value must only contain paths in %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\xfa\x01\n" +
-	"\x06not_in\x18\x03 \x03(\tB\xe2\x01\xc2H\xde\x01\n" +
-	"\xdb\x01\n" +
-	"\x11field_mask.not_in\x1a\xc5\x01!this.paths.all(p, !(p in getField(rules, 'not_in') || getField(rules, 'not_in').exists(f, p.startsWith(f+'.')))) ? 'value must not contain any paths in %s'.format([getField(rules, 'not_in')]) : ''R\x05notIn\x12U\n" +
+	"\fgreater_than\"\x86\x06\n" +
+	"\x0eFieldMaskRules\x12\xc0\x01\n" +
+	"\x05const\x18\x01 \x01(\v2\x1a.google.protobuf.FieldMaskB\x8d\x01\xc2H\x89\x01\n" +
+	"\x86\x01\n" +
+	"\x10field_mask.const\x1arthis.paths != getField(rules, 'const').paths ? 'must equal paths %s'.format([getField(rules, 'const').paths]) : ''R\x05const\x12\xd7\x01\n" +
+	"\x02in\x18\x02 \x03(\tB\xc6\x01\xc2H\xc2\x01\n" +
+	"\xbf\x01\n" +
+	"\rfield_mask.in\x1a\xad\x01!this.paths.all(p, p in getField(rules, 'in') || getField(rules, 'in').exists(f, p.startsWith(f+'.'))) ? 'must only contain paths in %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\xf4\x01\n" +
+	"\x06not_in\x18\x03 \x03(\tB\xdc\x01\xc2H\xd8\x01\n" +
+	"\xd5\x01\n" +
+	"\x11field_mask.not_in\x1a\xbf\x01!this.paths.all(p, !(p in getField(rules, 'not_in') || getField(rules, 'not_in').exists(f, p.startsWith(f+'.')))) ? 'must not contain any paths in %s'.format([getField(rules, 'not_in')]) : ''R\x05notIn\x12U\n" +
 	"\aexample\x18\x04 \x03(\v2\x1a.google.protobuf.FieldMaskB\x1f\xc2H\x1c\n" +
 	"\x1a\n" +
-	"\x12field_mask.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02\"\xca\x18\n" +
-	"\x0eTimestampRules\x12\xaa\x01\n" +
-	"\x05const\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampBx\xc2Hu\n" +
-	"s\n" +
-	"\x0ftimestamp.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\xaf\x01\n" +
-	"\x02lt\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampB\x80\x01\xc2H}\n" +
-	"{\n" +
-	"\ftimestamp.lt\x1ak!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'value must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xc1\x01\n" +
-	"\x03lte\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampB\x90\x01\xc2H\x8c\x01\n" +
-	"\x89\x01\n" +
-	"\rtimestamp.lte\x1ax!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'value must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12s\n" +
-	"\x06lt_now\x18\a \x01(\bBZ\xc2HW\n" +
-	"U\n" +
-	"\x10timestamp.lt_now\x1aA(rules.lt_now && this > now) ? 'value must be less than now' : ''H\x00R\x05ltNow\x12\xcb\a\n" +
-	"\x02gt\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampB\x9c\a\xc2H\x98\a\n" +
-	"~\n" +
-	"\ftimestamp.gt\x1an!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'value must be greater than %s'.format([rules.gt]) : ''\n" +
-	"\xb7\x01\n" +
-	"\x0ftimestamp.gt_lt\x1a\xa3\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'value must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xbf\x01\n" +
-	"\x19timestamp.gt_lt_exclusive\x1a\xa1\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'value must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
-	"\xc7\x01\n" +
-	"\x10timestamp.gt_lte\x1a\xb2\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'value must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
-	"\xcf\x01\n" +
-	"\x1atimestamp.gt_lte_exclusive\x1a\xb0\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'value must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\x98\b\n" +
-	"\x03gte\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampB\xe7\a\xc2H\xe3\a\n" +
-	"\x8c\x01\n" +
-	"\rtimestamp.gte\x1a{!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'value must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
-	"\xc6\x01\n" +
-	"\x10timestamp.gte_lt\x1a\xb1\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'value must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xce\x01\n" +
-	"\x1atimestamp.gte_lt_exclusive\x1a\xaf\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'value must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
-	"\xd6\x01\n" +
-	"\x11timestamp.gte_lte\x1a\xc0\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'value must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
-	"\xde\x01\n" +
-	"\x1btimestamp.gte_lte_exclusive\x1a\xbe\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'value must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12v\n" +
-	"\x06gt_now\x18\b \x01(\bB]\xc2HZ\n" +
-	"X\n" +
-	"\x10timestamp.gt_now\x1aD(rules.gt_now && this < now) ? 'value must be greater than now' : ''H\x01R\x05gtNow\x12\xc0\x01\n" +
-	"\x06within\x18\t \x01(\v2\x19.google.protobuf.DurationB\x8c\x01\xc2H\x88\x01\n" +
-	"\x85\x01\n" +
-	"\x10timestamp.within\x1aqthis < now-rules.within || this > now+rules.within ? 'value must be within %s of now'.format([rules.within]) : ''R\x06within\x12T\n" +
+	"\x12field_mask.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02\"\xe8\x17\n" +
+	"\x0eTimestampRules\x12\xa4\x01\n" +
+	"\x05const\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampBr\xc2Ho\n" +
+	"m\n" +
+	"\x0ftimestamp.const\x1aZthis != getField(rules, 'const') ? 'must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\xa8\x01\n" +
+	"\x02lt\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampBz\xc2Hw\n" +
+	"u\n" +
+	"\ftimestamp.lt\x1ae!has(rules.gte) && !has(rules.gt) && this >= rules.lt? 'must be less than %s'.format([rules.lt]) : ''H\x00R\x02lt\x12\xbb\x01\n" +
+	"\x03lte\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampB\x8a\x01\xc2H\x86\x01\n" +
+	"\x83\x01\n" +
+	"\rtimestamp.lte\x1ar!has(rules.gte) && !has(rules.gt) && this > rules.lte? 'must be less than or equal to %s'.format([rules.lte]) : ''H\x00R\x03lte\x12m\n" +
+	"\x06lt_now\x18\a \x01(\bBT\xc2HQ\n" +
+	"O\n" +
+	"\x10timestamp.lt_now\x1a;(rules.lt_now && this > now) ? 'must be less than now' : ''H\x00R\x05ltNow\x12\xad\a\n" +
+	"\x02gt\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampB\xfe\x06\xc2H\xfa\x06\n" +
+	"x\n" +
+	"\ftimestamp.gt\x1ah!has(rules.lt) && !has(rules.lte) && this <= rules.gt? 'must be greater than %s'.format([rules.gt]) : ''\n" +
+	"\xb1\x01\n" +
+	"\x0ftimestamp.gt_lt\x1a\x9d\x01has(rules.lt) && rules.lt >= rules.gt && (this >= rules.lt || this <= rules.gt)? 'must be greater than %s and less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xb9\x01\n" +
+	"\x19timestamp.gt_lt_exclusive\x1a\x9b\x01has(rules.lt) && rules.lt < rules.gt && (rules.lt <= this && this <= rules.gt)? 'must be greater than %s or less than %s'.format([rules.gt, rules.lt]) : ''\n" +
+	"\xc1\x01\n" +
+	"\x10timestamp.gt_lte\x1a\xac\x01has(rules.lte) && rules.lte >= rules.gt && (this > rules.lte || this <= rules.gt)? 'must be greater than %s and less than or equal to %s'.format([rules.gt, rules.lte]) : ''\n" +
+	"\xc9\x01\n" +
+	"\x1atimestamp.gt_lte_exclusive\x1a\xaa\x01has(rules.lte) && rules.lte < rules.gt && (rules.lte < this && this <= rules.gt)? 'must be greater than %s or less than or equal to %s'.format([rules.gt, rules.lte]) : ''H\x01R\x02gt\x12\xfa\a\n" +
+	"\x03gte\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampB\xc9\a\xc2H\xc5\a\n" +
+	"\x86\x01\n" +
+	"\rtimestamp.gte\x1au!has(rules.lt) && !has(rules.lte) && this < rules.gte? 'must be greater than or equal to %s'.format([rules.gte]) : ''\n" +
+	"\xc0\x01\n" +
+	"\x10timestamp.gte_lt\x1a\xab\x01has(rules.lt) && rules.lt >= rules.gte && (this >= rules.lt || this < rules.gte)? 'must be greater than or equal to %s and less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xc8\x01\n" +
+	"\x1atimestamp.gte_lt_exclusive\x1a\xa9\x01has(rules.lt) && rules.lt < rules.gte && (rules.lt <= this && this < rules.gte)? 'must be greater than or equal to %s or less than %s'.format([rules.gte, rules.lt]) : ''\n" +
+	"\xd0\x01\n" +
+	"\x11timestamp.gte_lte\x1a\xba\x01has(rules.lte) && rules.lte >= rules.gte && (this > rules.lte || this < rules.gte)? 'must be greater than or equal to %s and less than or equal to %s'.format([rules.gte, rules.lte]) : ''\n" +
+	"\xd8\x01\n" +
+	"\x1btimestamp.gte_lte_exclusive\x1a\xb8\x01has(rules.lte) && rules.lte < rules.gte && (rules.lte < this && this < rules.gte)? 'must be greater than or equal to %s or less than or equal to %s'.format([rules.gte, rules.lte]) : ''H\x01R\x03gte\x12p\n" +
+	"\x06gt_now\x18\b \x01(\bBW\xc2HT\n" +
+	"R\n" +
+	"\x10timestamp.gt_now\x1a>(rules.gt_now && this < now) ? 'must be greater than now' : ''H\x01R\x05gtNow\x12\xb9\x01\n" +
+	"\x06within\x18\t \x01(\v2\x19.google.protobuf.DurationB\x85\x01\xc2H\x81\x01\n" +
+	"\x7f\n" +
+	"\x10timestamp.within\x1akthis < now-rules.within || this > now+rules.within ? 'must be within %s of now'.format([rules.within]) : ''R\x06within\x12T\n" +
 	"\aexample\x18\n" +
 	" \x03(\v2\x1a.google.protobuf.TimestampB\x1e\xc2H\x1b\n" +
 	"\x19\n" +
@@ -9019,6 +9112,8 @@ func file_buf_validate_validate_proto_init() {
 		(*StringRules_Ipv6Prefix)(nil),
 		(*StringRules_HostAndPort)(nil),
 		(*StringRules_Ulid)(nil),
+		(*StringRules_ProtobufFqn)(nil),
+		(*StringRules_ProtobufDotFqn)(nil),
 		(*StringRules_WellKnownRegex)(nil),
 	}
 	file_buf_validate_validate_proto_msgTypes[20].OneofWrappers = []any{

--- a/gen/raystack/compass/v1beta1/service.pb.go
+++ b/gen/raystack/compass/v1beta1/service.pb.go
@@ -684,8 +684,6 @@ type UpsertEntityRequest struct {
 	Description   string                 `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
 	Properties    *structpb.Struct       `protobuf:"bytes,5,opt,name=properties,proto3" json:"properties,omitempty"`
 	Source        string                 `protobuf:"bytes,6,opt,name=source,proto3" json:"source,omitempty"`
-	Upstreams     []string               `protobuf:"bytes,7,rep,name=upstreams,proto3" json:"upstreams,omitempty"`
-	Downstreams   []string               `protobuf:"bytes,8,rep,name=downstreams,proto3" json:"downstreams,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -760,20 +758,6 @@ func (x *UpsertEntityRequest) GetSource() string {
 		return x.Source
 	}
 	return ""
-}
-
-func (x *UpsertEntityRequest) GetUpstreams() []string {
-	if x != nil {
-		return x.Upstreams
-	}
-	return nil
-}
-
-func (x *UpsertEntityRequest) GetDownstreams() []string {
-	if x != nil {
-		return x.Downstreams
-	}
-	return nil
 }
 
 type UpsertEntityResponse struct {
@@ -2680,7 +2664,7 @@ var File_raystack_compass_v1beta1_service_proto protoreflect.FileDescriptor
 
 const file_raystack_compass_v1beta1_service_proto_rawDesc = "" +
 	"\n" +
-	"&raystack/compass/v1beta1/service.proto\x12\x18raystack.compass.v1beta1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bbuf/validate/validate.proto\"\xd2\x01\n" +
+	"&raystack/compass/v1beta1/service.proto\x12\x18raystack.compass.v1beta1\x1a\x1bbuf/validate/validate.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd2\x01\n" +
 	"\x04User\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04uuid\x18\x02 \x01(\tR\x04uuid\x12\x14\n" +
@@ -2744,7 +2728,7 @@ const file_raystack_compass_v1beta1_service_proto_rawDesc = "" +
 	"\x14GetEntityByIDRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"M\n" +
 	"\x15GetEntityByIDResponse\x124\n" +
-	"\x04data\x18\x01 \x01(\v2 .raystack.compass.v1beta1.EntityR\x04data\"\x9d\x02\n" +
+	"\x04data\x18\x01 \x01(\v2 .raystack.compass.v1beta1.EntityR\x04data\"\x81\x02\n" +
 	"\x13UpsertEntityRequest\x12\x19\n" +
 	"\x03urn\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x03urn\x12\x1b\n" +
 	"\x04type\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x04type\x12\x1b\n" +
@@ -2753,9 +2737,7 @@ const file_raystack_compass_v1beta1_service_proto_rawDesc = "" +
 	"\n" +
 	"properties\x18\x05 \x01(\v2\x17.google.protobuf.StructR\n" +
 	"properties\x12\x16\n" +
-	"\x06source\x18\x06 \x01(\tR\x06source\x12\x1c\n" +
-	"\tupstreams\x18\a \x03(\tR\tupstreams\x12 \n" +
-	"\vdownstreams\x18\b \x03(\tR\vdownstreams\"&\n" +
+	"\x06source\x18\x06 \x01(\tR\x06sourceJ\x04\b\a\x10\bJ\x04\b\b\x10\tR\tupstreamsR\vdownstreams\"&\n" +
 	"\x14UpsertEntityResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"0\n" +
 	"\x13DeleteEntityRequest\x12\x19\n" +

--- a/handler/entity.go
+++ b/handler/entity.go
@@ -16,7 +16,6 @@ import (
 // EntityServiceV2 defines entity operations for the handler.
 type EntityServiceV2 interface {
 	Upsert(ctx context.Context, ns *namespace.Namespace, ent *entity.Entity) (string, error)
-	UpsertWithEdges(ctx context.Context, ns *namespace.Namespace, ent *entity.Entity, upstreams, downstreams []string) (string, error)
 	GetByURN(ctx context.Context, ns *namespace.Namespace, urn string) (entity.Entity, error)
 	GetByID(ctx context.Context, id string) (entity.Entity, error)
 	GetAll(ctx context.Context, ns *namespace.Namespace, flt entity.Filter) ([]entity.Entity, int, error)
@@ -93,8 +92,7 @@ func (server *Handler) UpsertEntity(ctx context.Context, req *connect.Request[co
 		ent.Properties = req.Msg.GetProperties().AsMap()
 	}
 
-	id, err := server.entityService.UpsertWithEdges(ctx, ns, ent,
-		req.Msg.GetUpstreams(), req.Msg.GetDownstreams())
+	id, err := server.entityService.Upsert(ctx, ns, ent)
 	if err != nil {
 		return nil, internalServerError(ctx, "error upserting entity", err)
 	}


### PR DESCRIPTION
All relationships including data lineage are now sent as edges via UpsertEdge. Remove UpsertWithEdges service method and the special handling that converted upstreams/downstreams arrays into lineage edges. Regenerate protos from updated proton that removes the upstreams/downstreams fields from UpsertEntityRequest.

Edge types are now descriptive:
- derived_from: entity depends on target (view from table, dashboard from datasource)
- generates: entity produces target (job writes to downstream)
- owned_by, member_of, belongs_to, references, consumed_by